### PR TITLE
Replace absolute URLs with relative URLs (with absolute path)

### DIFF
--- a/source/documentation/archive/serving_data/fuseki1.md
+++ b/source/documentation/archive/serving_data/fuseki1.md
@@ -5,11 +5,9 @@ title: "Fuseki: serving RDF data over HTTP"
 ## See the [Fuseki2 documentation](/documentation/fuseki2/).
 
 ----
-> This page covers Fuseki v1.
-> Fuseki1 is deprecated and has been retired. 
-> The last release of Jena with this module is Jena 3.9.0.
-> See [jena-fuseki1/README.md](https://github.com/apache/jena/tree/master/fuseki1).
-> This is the original documentation.
+> This page covers Fuseki v1.<br/>
+> Fuseki1 is deprecated and has been retired.<br/>
+> The last release of Jena with this module is Jena 3.9.0.<br/>
 ----
 
 Fuseki is a SPARQL server. It provides REST-style SPARQL HTTP Update, SPARQL Query,
@@ -47,7 +45,7 @@ The source code is available in the Apache Jena source release.
 
 This section provides a brief guide to getting up and running with
 a simple server installation. It uses the
-[SOH (SPARQL over HTTP)](../fuseki2/soh.html) scripts included in the
+[SOH (SPARQL over HTTP)](/documentation/fuseki2/soh.html) scripts included in the
 download.
 
 1.  [Download](/download/#jena-fuseki) the latest `jena-fuseki-*-distribution` 
@@ -218,7 +216,7 @@ accessed via the appropriate protocol at the following URLs:
 -   SPARQL update: `http://localhost:3030/ds/update`
 -   SPARQL HTTP update: `http://localhost:3030/ds/data`
 
-The [SPARQL Over HTTP](soh.html) scripts take care of naming
+The [SPARQL Over HTTP](/documentation/fuseki2/soh.html) scripts take care of naming
 and protocol details. For example, to load in a file `data.rdf`:
 
      s-put http://localhost:3030/ds/data default data.rdf
@@ -416,7 +414,7 @@ or making the default graph the union of all named graphs.
 working with SPARQL 1.1. SOH is server-independent and will work
 with any compliant SPARQL 1.1 system offering HTTP access.
 
-See the [SPARQL Over HTTP](soh.html) page.
+See the [SPARQL Over HTTP](/documentation/fuseki2/soh.html) page.
 
 ### Examples
 

--- a/source/documentation/csv/get_started.md
+++ b/source/documentation/csv/get_started.md
@@ -4,7 +4,7 @@ title: CSV PropertyTable - Get Started
 
 ## Using CSV PropertyTable with Apache Maven
 
-See ["Using Jena with Apache Maven"](http://jena.apache.org/download/maven.html) for full details.
+See ["Using Jena with Apache Maven"](/download/maven.html) for full details.
 
     <dependency>
        <groupId>org.apache.jena</groupId>
@@ -14,7 +14,7 @@ See ["Using Jena with Apache Maven"](http://jena.apache.org/download/maven.html)
 
 ## Using CSV PropertyTable from Java through the API
 
-In order to switch on CSV PropertyTable, it's required to register `LangCSV` into [Jena RIOT](http://jena.apache.org/documentation/io/), through a simple method call:
+In order to switch on CSV PropertyTable, it's required to register `LangCSV` into [Jena RIOT](/documentation/io/), through a simple method call:
 
 	import org.apache.jena.propertytable.lang.CSV2RDF;
 	... 
@@ -58,7 +58,7 @@ You can read ".csv" files into Model following the standard RIOT usages:
     // Usage 2: Reading using RDFDataMgr
     Model model_2 = RDFDataMgr.loadModel("test.csv") ;
 
-For more information, see [Reading RDF in Apache Jena](http://jena.apache.org/documentation/io/rdf-input.html).
+For more information, see [Reading RDF in Apache Jena](/documentation/io/rdf-input.html).
 
 Note that, the requirements for the CSV files are listed in the documentation of [Design](design.html). CSV PropertyTable only supports **single-Value**, **regular-Shaped**, **table-headed** and **UTF-8-encoded** CSV files (**NOT** Microsoft Excel files).
 
@@ -76,7 +76,7 @@ It transforms the CSV `inputFile` into N-Triples. For example,
 The script reuses [Common framework for running RIOT parsers](../io/index.html),
 so that it also accepts the same arguments
 (type `"riot --help"` to get command line reminders) from 
-[RIOT Command line tools](https://jena.apache.org/documentation/io/#command-line-tools):
+[RIOT Command line tools](/documentation/io/#command-line-tools):
 
 -   `--validate`: Checking mode: same as `--strict --sink --check=true`
 -   `--check=true/false`: Run with checking of literals and IRIs either on or off.

--- a/source/documentation/fuseki2/__index.md
+++ b/source/documentation/fuseki2/__index.md
@@ -121,8 +121,3 @@ Development builds (not a formal release):
 
 Source code mirrored to github:
 [https://github.com/apache/jena/tree/master/jena-fuseki2](https://github.com/apache/jena/tree/master/jena-fuseki2)
-
-## Fuseki 1
-
-Fuseki 1 is still available for legacy use. 
-[Documentation for Fuseki1](/documentation/serving_data/).

--- a/source/documentation/fuseki2/data-access-control.md
+++ b/source/documentation/fuseki2/data-access-control.md
@@ -6,7 +6,7 @@ Fuseki can provide access control at the level on the server, on datasets,
 on endpoints and also on specific graphs within a dataset. It also
 provides native https to protect data in-flight.
 
-[Fuseki Main](http://jena.apache.org/documentation/fuseki2/fuseki-main.html)
+[Fuseki Main](/documentation/fuseki2/fuseki-main.html)
 provides some common patterns of authentication.
 
 [Graph level Data Access Control](#graph-acl) provides control over the visibility of
@@ -15,7 +15,7 @@ the default graph. Currently, Graph level access control only applies to
 read-only datasets.
 
 Fuseki Full (Fuseki with the UI) can be used when
-[run in a web application server such as Tomcat](http://jena.apache.org/documentation/fuseki2/fuseki-run.html#fuseki-web-application)
+[run in a web application server such as Tomcat](/documentation/fuseki2/fuseki-run.html#fuseki-web-application)
 to provide authentication of the user.  See "[Fuseki Security](fuseki-security)" for configuring security over the whole of the Fuseki UI.
 
 ## Contents

--- a/source/documentation/fuseki2/fuseki-main.md
+++ b/source/documentation/fuseki2/fuseki-main.md
@@ -33,8 +33,7 @@ persistent work area on-disk.
     java -jar jena-fuseki-server-$VER.jar --help
 
 The arguments are the same as the 
-[full UI server command line
-program](http://jena.apache.org/documentation/fuseki2/fuseki-run.html#fuseki-standalone-server).
+[full UI server command line program](/documentation/fuseki2/fuseki-run.html#fuseki-standalone-server).
 There are no special environment variables.
 
 
@@ -98,7 +97,7 @@ is quite large and difficult to set manually.
 This dependency does not include a logging setting. Fuseki uses [slf4j](http://slf4j.org/).
 See section "[Logging](#logging)" for details.
 
-If the application wishes to use a dataset with a [text-index](http://jena.apache.org/documentation/query/text-query.html)
+If the application wishes to use a dataset with a [text-index](/documentation/query/text-query.html)
 then the application will also need to include jena-text in its dependencies.
 
 ## Logging {#logging}
@@ -136,7 +135,7 @@ and dependencies:
       <version>1.x.y</version>
     </dependency>
 
-See [Fuseki Logging](http://jena.apache.org/documentation/fuseki2/fuseki-logging.html).
+See [Fuseki Logging](/documentation/fuseki2/fuseki-logging.html).
 
 To silence logging from Java, try:
 

--- a/source/documentation/geosparql/__index.md
+++ b/source/documentation/geosparql/__index.md
@@ -113,7 +113,6 @@ To query a Model with GeoSPARQL or standard SPARQL:
         ResultSetFormatter.outputAsTSV(rs);
     }
 
-More information on SPARQL querying using Jena can be found on their website (https://jena.apache.org/tutorials/sparql.html).
 If your dataset needs to be separate from your application and accessed over HTTP then you probably need
 the [GeoSPARQL Fuseki project](geosparql-fuseki).
 The GeoSPARQL functionality needs to be setup in the application or Fuseki server where the dataset is located.
@@ -183,7 +182,7 @@ The following are implementation points that may be useful during usage.
 
 ### GeoSPARQL Schema
 An RDF/XML schema has been published for the GeoSPARQL v1.0 standard (v1.0.1 - http://schemas.opengis.net/geosparql/1.0/geosparql_vocab_all.rdf).
-This can be applied to Jena Models (https://jena.apache.org/documentation/inference/) to provide RDFS and OWL inferencing on a GeoSPARQL conforming dataset.
+This can be applied to Jena Models (see [the inference documentation](/documentation/inference/)) to provide RDFS and OWL inferencing on a GeoSPARQL conforming dataset.
 However, the published schema does not conform with the standard.
 
 The property `hasDefaultGeometry` is missing from the schema and instead the `defaultGeometry` property is stated.

--- a/source/documentation/io/rdf-input.md
+++ b/source/documentation/io/rdf-input.md
@@ -117,7 +117,7 @@ add data into an existing model or dataset.
 
 Detail control over the setup of the parsing process is provided by
 `RDFParser` which provides a builder pattern.  It has many options - see
-[the javadoc for all details](http://jena.apache.org/documentation/javadoc/arq/org/apache/jena/riot/RDFParser.html).
+[the javadoc for all details](/documentation/javadoc/arq/org/apache/jena/riot/RDFParser.html).
 
 For example, to read Trig data, and set the error handler specially,
 

--- a/source/documentation/jdbc/drivers.md
+++ b/source/documentation/jdbc/drivers.md
@@ -156,7 +156,7 @@ All of these may be specified multiple times to specify multiple graph URIs for 
 
 Then you have the `select-results-type` and `model-results-type` which are used to set the MIME
 type you'd prefer to have the driver retrieve SPARQL results from the remote endpoints in.  If used
-you must set them to formats that ARQ supports, the ARQ [WebContent](http://jena.staging.apache.org/documentation/javadoc/arq/org/apache/jena/riot/WebContent.html)
+you must set them to formats that ARQ supports, the ARQ [WebContent](/documentation/javadoc/arq/org/apache/jena/riot/WebContent.html)
 class has constants for the various supported formats.
 
 #### Authentication

--- a/source/documentation/query/__index.md
+++ b/source/documentation/query/__index.md
@@ -3,7 +3,7 @@ title: ARQ - A SPARQL Processor for Jena
 slug: index
 ---
 
-ARQ is a query engine for [Jena](http://jena.apache.org) that
+ARQ is a query engine for [Jena](https://jena.apache.org/) that
 supports the
 [SPARQL RDF Query language](http://www.w3.org/TR/sparql11-query/).
 SPARQL is the query language developed by the W3C

--- a/source/documentation/query/construct-quad.md
+++ b/source/documentation/query/construct-quad.md
@@ -73,7 +73,7 @@ TriplesTemplate           | ::= | TriplesSameSubject ( '.' TriplesTemplate? )?
 
 ## Programming API
 
-ARQ provides 2 additional methods in [QueryExecution](http://jena.apache.org/documentation/javadoc/arq/org/apache/jena/query/QueryExecution.html) for Construct Quad.
+ARQ provides 2 additional methods in [QueryExecution](/documentation/javadoc/arq/org/apache/jena/query/QueryExecution.html) for Construct Quad.
 
     Iterator<Quad> QueryExecution.execConstructQuads() // allow duplication
     Dataset QueryExecution.execConstructDataset() // no duplication
@@ -109,10 +109,10 @@ More examples can be found at `ExampleConstructQuads.java` under `jena-arq/src-e
 
 ## Fuseki Support
 
-Jena [Fuseki](http://jena.apache.org/documentation/fuseki2/index.html) is also empowered with Construct Quad query as a built-in
+Jena [Fuseki](/documentation/fuseki2/index.html) is also empowered with Construct Quad query as a built-in
 function. No more additional configuration is required to switch it on.
 Because
-[QueryEngineHTTP](http://jena.apache.org/documentation/javadoc/arq/org/apache/jena/sparql/engine/http/QueryEngineHTTP.html)
+[QueryEngineHTTP](/documentation/javadoc/arq/org/apache/jena/sparql/engine/http/QueryEngineHTTP.html)
 is just an implementation of QueryExecution, there's no much difference
 for the client users to manipulate the programming API described in the
 previous sections, e.g.

--- a/source/documentation/query/generate-json-from-sparql.md
+++ b/source/documentation/query/generate-json-from-sparql.md
@@ -100,7 +100,7 @@ JsonObjectMember          | ::= | String ':' ( Var &#x7C; RDFLiteral &#x7C; Nume
 
 ## Programming API
 
-ARQ provides 2 additional methods in [QueryExecution](http://jena.apache.org/documentation/javadoc/arq/org/apache/jena/query/QueryExecution.html) for JSON.
+ARQ provides 2 additional methods in [QueryExecution](/documentation/javadoc/arq/org/apache/jena/query/QueryExecution.html) for JSON.
 
     Iterator<JsonObject> QueryExecution.execJsonItems()
     JsonArray QueryExecution.execJson()

--- a/source/documentation/query/http-auth.md
+++ b/source/documentation/query/http-auth.md
@@ -210,21 +210,21 @@ HTTP traces i.e. allow you to see the exact HTTP requests and responses which ca
 
 ARQ allows the user to configure HTTP behavior to use on a per-`SERVICE` basis, including authentication behavior such as is described above. This works via the ARQ context. See [Basic Federated Query][5] for more information on configuring this functionality.
 
-  [1]: http://jena.apache.org/documentation/javadoc/arq/org/apache/jena/atlas/web/auth/HttpAuthenticator.html
-  [2]: http://jena.apache.org/documentation/javadoc/arq/org/apache/jena/atlas/web/auth/SimpleAuthenticator.html
-  [3]: http://jena.apache.org/documentation/javadoc/arq/org/apache/jena/atlas/web/auth/ScopedAuthenticator.html
-  [4]: http://jena.apache.org/documentation/javadoc/arq/org/apache/jena/atlas/web/auth/ServiceAuthenticator.html
+  [1]: /documentation/javadoc/arq/org/apache/jena/atlas/web/auth/HttpAuthenticator.html
+  [2]: /documentation/javadoc/arq/org/apache/jena/atlas/web/auth/SimpleAuthenticator.html
+  [3]: /documentation/javadoc/arq/org/apache/jena/atlas/web/auth/ScopedAuthenticator.html
+  [4]: /documentation/javadoc/arq/org/apache/jena/atlas/web/auth/ServiceAuthenticator.html
   [5]: service.html
-  [6]: http://jena.apache.org/documentation/javadoc/arq/org/apache/jena/atlas/web/auth/FormsAuthenticator.html
+  [6]: /documentation/javadoc/arq/org/apache/jena/atlas/web/auth/FormsAuthenticator.html
   [7]: https://httpd.apache.org/docs/2.4/mod/mod_auth_form.html
-  [8]: http://jena.apache.org/documentation/javadoc/arq/org/apache/jena/atlas/web/auth/PreemptiveBasicAuthenticator.html
-  [9]: http://jena.apache.org/documentation/javadoc/arq/org/apache/jena/sparql/engine/http/QueryEngineHTTP.html
-  [10]: http://jena.apache.org/documentation/javadoc/arq/org/apache/jena/sparql/modify/UpdateProcessRemoteBase.html
-  [11]: http://jena.apache.org/documentation/javadoc/arq/org/apache/jena/web/DatasetGraphAccessorHTTP.html
-  [12]: http://jena.apache.org/documentation/javadoc/arq/org/apache/jena/atlas/web/auth/DelegatingAuthenticator.html
-  [13]: http://jena.apache.org/documentation/javadoc/arq/org/apache/jena/riot/web/HttpOp.html
+  [8]: /documentation/javadoc/arq/org/apache/jena/atlas/web/auth/PreemptiveBasicAuthenticator.html
+  [9]: /documentation/javadoc/arq/org/apache/jena/sparql/engine/http/QueryEngineHTTP.html
+  [10]: /documentation/javadoc/arq/org/apache/jena/sparql/modify/UpdateProcessRemoteBase.html
+  [11]: /documentation/javadoc/arq/org/apache/jena/web/DatasetGraphAccessorHTTP.html
+  [12]: /documentation/javadoc/arq/org/apache/jena/atlas/web/auth/DelegatingAuthenticator.html
+  [13]: /documentation/javadoc/arq/org/apache/jena/riot/web/HttpOp.html
   [14]: http://hc.apache.org
   [15]: https://hc.apache.org/httpcomponents-client-ga/httpclient/apidocs/org/apache/http/client/HttpClient.html
   [16]: https://hc.apache.org/httpcomponents-client-ga/examples.html
   [17]: https://hc.apache.org/httpcomponents-client-ga/httpclient/apidocs/org/apache/http/client/protocol/HttpClientContext.html
-  [18]: https://jena.apache.org/documentation/javadoc/arq/org/apache/jena/query/QueryExecutionFactory.html
+  [18]: /documentation/javadoc/arq/org/apache/jena/query/QueryExecutionFactory.html

--- a/source/documentation/query/parameterized-sparql-strings.md
+++ b/source/documentation/query/parameterized-sparql-strings.md
@@ -70,7 +70,7 @@ Note that the state of the instance returned by `toString()` will include any in
 does is check that your command is not subject to SPARQL injection attacks so in some cases where a possible
 injection is detected an `ARQException` will be thrown.
 
-[1]: http://jena.apache.org/documentation/javadoc/arq/org/apache/jena/query/ParameterizedSparqlString.html
+[1]: /documentation/javadoc/arq/org/apache/jena/query/ParameterizedSparqlString.html
 
 ### Injecting Values
 

--- a/source/documentation/query/spatial-query.md
+++ b/source/documentation/query/spatial-query.md
@@ -160,7 +160,7 @@ See [ESRIs docs on spatial relations](http://edndoc.esri.com/arcsde/9.1/general_
 
 ## Spatial Dataset Assembler
 
-The usual way to describe an index is with a [Jena assembler description](http://jena.apache.org/documentation/assembler/index.html). Configurations can also be built with [code](#how-to-use-it-by-code). The assembler describes a "spatial dataset" which has an underlying RDF dataset and a spatial index. The spatial index describes the spatial index technology (Lucene or Solr) and the details needed for each.
+The usual way to describe an index is with a [Jena assembler description](/documentation/assembler/index.html). Configurations can also be built with [code](#how-to-use-it-by-code). The assembler describes a "spatial dataset" which has an underlying RDF dataset and a spatial index. The spatial index describes the spatial index technology (Lucene or Solr) and the details needed for each.
 
 A spatial index has an 
 [EntityDefinition](https://github.com/apache/jena/tree/master/jena-spatial/src/main/java/org/apache/jena/query/spatial/EntityDefinition.java)

--- a/source/documentation/query/text-query.md
+++ b/source/documentation/query/text-query.md
@@ -44,7 +44,7 @@ structure of string literals rather than treating such literals as
 opaque items.  Unlike `FILTER`, an index can set the values of variables.
 Assuming appropriate [configuration](#configuration), the
 above query can use full text search via the
-[ARQ property function extension](https://jena.apache.org/documentation/query/extension.html#property-functions), `text:query`:
+[ARQ property function extension](/documentation/query/extension.html#property-functions), `text:query`:
 
     PREFIX   ex: <http://www.example.org/resources#>
     PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>

--- a/source/documentation/query/writing_propfuncs.md
+++ b/source/documentation/query/writing_propfuncs.md
@@ -7,7 +7,7 @@ title: ARQ - Writing Property Functions
 See also [Writing Filter Functions](writing_functions.html).
 
 Applications can add SPARQL property functions to the query engine. This is done by first implementing the
- [`PropertyFunction`](http://jena.apache.org/documentation/javadoc/arq/org/apache/jena/sparql/pfunction/PropertyFunction.html)
+ [`PropertyFunction`](/documentation/javadoc/arq/org/apache/jena/sparql/pfunction/PropertyFunction.html)
  interface, and then either registering that function or using the fake `java:` URI scheme to dynamically
  load the function.
 
@@ -18,7 +18,7 @@ Similar to SPARQL Filter Functions, a SPARQL Property Function is an extension p
  generate new bindings.
 
 Just like
- [org.apache.jena.sparql.function.Function](http://jena.apache.org/documentation/javadoc/arq/org/apache/jena/sparql/function/Function.html)
+ [org.apache.jena.sparql.function.Function](/documentation/javadoc/arq/org/apache/jena/sparql/function/Function.html)
  there are various utility classes provided to simplify the creation of a Property Function. The selection of
  one depends on the 'style' of the desired built-in. For example, `PFuncSimple` is expected to be the predicate
  of triple patterns `?such ex:as ?this`, where neither argument is an `rdf:list`, and either may be a variable.
@@ -44,8 +44,8 @@ Just like
 
 The choice of extension point determines the function signature that the developer will need to implement, and
  primarily determines whether some of the arguments will be 
- [`org.apache.jena.graph.Node`](https://jena.apache.org/documentation/javadoc/jena/org/apache/jena/graph/Node.html)s or 
- [`org.apache.jena.sparql.pfunction.PropFuncArg`](http://jena.apache.org/documentation/javadoc/arq/org/apache/jena/sparql/pfunction/PropFuncArg.html)s.
+ [`org.apache.jena.graph.Node`](/documentation/javadoc/jena/org/apache/jena/graph/Node.html)s or 
+ [`org.apache.jena.sparql.pfunction.PropFuncArg`](/documentation/javadoc/arq/org/apache/jena/sparql/pfunction/PropFuncArg.html)s.
  In the latter case, the programmer can determine whether the argument is a list as well as how many
  arguments it consists of.
 
@@ -53,13 +53,13 @@ The choice of extension point determines the function signature that the develop
 **Registration**
 
 Every property function is associated with a particular 
- [`org.apache.jena.sparql.util.Context`](http://jena.apache.org/documentation/javadoc/arq/org/apache/jena/sparql/util/Context.html).
+ [`org.apache.jena.sparql.util.Context`](/documentation/javadoc/arq/org/apache/jena/sparql/util/Context.html).
  This allows you to limit the availability of the function to be global or associated with a particular dataset.
  For example, a custom Property Function may expose an index which only has meaning with respect to some set
  of data.
 
 Assuming you have an implementation of
- [`org.apache.jena.sparql.pfunction.PropertyFunctionFactory`](http://jena.apache.org/documentation/javadoc/arq/org/apache/jena/sparql/pfunction/PropertyFunctionFactory.html) 
+ [`org.apache.jena.sparql.pfunction.PropertyFunctionFactory`](/documentation/javadoc/arq/org/apache/jena/sparql/pfunction/PropertyFunctionFactory.html) 
  (shown later), you can register a function as follows:
 
 
@@ -76,7 +76,7 @@ The only difference between global and dataset-specific registration is where th
     PropertyFunctionRegistry.set(ds.getContext(), reg);
 
 Note that 
- [`org.apache.jena.sparql.pfunction.PropertyFunctionRegistry`](http://jena.apache.org/documentation/javadoc/arq/org/apache/jena/sparql/pfunction/PropertyFunctionRegistry.html)
+ [`org.apache.jena.sparql.pfunction.PropertyFunctionRegistry`](/documentation/javadoc/arq/org/apache/jena/sparql/pfunction/PropertyFunctionRegistry.html)
  has other `put` methods that allow registration by passing a `Class` object, as well.
 
 **Implementation**
@@ -117,14 +117,14 @@ easy to support typical use cases.
 
 Of particular note:
 
-  - [`QueryIterNullIterator`](https://jena.apache.org/documentation/javadoc/arq/org/apache/jena/sparql/engine/iterator/QueryIterNullIterator.html) - to indicate that there are no valid solutions/bindings for the given values
-  - [`QueryIterSingleton`](https://jena.apache.org/documentation/javadoc/arq/org/apache/jena/sparql/engine/iterator/QueryIterSingleton.html) - to provide a single solution/binding for the given values
-  - [`QueryIterPlainWrapper`](http://jena.apache.org/documentation/javadoc/arq/org/apache/jena/sparql/engine/iterator/QueryIterPlainWrapper.html) - to provide multiple solutions/bindings for the given values
+  - [`QueryIterNullIterator`](/documentation/javadoc/arq/org/apache/jena/sparql/engine/iterator/QueryIterNullIterator.html) - to indicate that there are no valid solutions/bindings for the given values
+  - [`QueryIterSingleton`](/documentation/javadoc/arq/org/apache/jena/sparql/engine/iterator/QueryIterSingleton.html) - to provide a single solution/binding for the given values
+  - [`QueryIterPlainWrapper`](/documentation/javadoc/arq/org/apache/jena/sparql/engine/iterator/QueryIterPlainWrapper.html) - to provide multiple solutions/bindings for the given values
 
 The second two cases require instances of `Binding` objects which can be obtained through static methods of
- [`BindingFactory`](http://jena.apache.org/documentation/javadoc/arq/org/apache/jena/sparql/engine/binding/BindingFactory.html).
- Creation of `Binding` objects will also require references to [`Var`](https://jena.apache.org/documentation/javadoc/arq/org/apache/jena/sparql/core/Var.html)
- and [`NodeFactory`](https://jena.apache.org/documentation/javadoc/jena/org/apache/jena/graph/NodeFactory.html)
+ [`BindingFactory`](/documentation/javadoc/arq/org/apache/jena/sparql/engine/binding/BindingFactory.html).
+ Creation of `Binding` objects will also require references to [`Var`](/documentation/javadoc/arq/org/apache/jena/sparql/core/Var.html)
+ and [`NodeFactory`](/documentation/javadoc/jena/org/apache/jena/graph/NodeFactory.html)
 
 Note that it can make a lot of sense to generate the `Iterator<Binding>` for `QueryIterPlainWrapper` by means of
  Jena's `ExtendedIterator`. This can allow domain-specific value to be easily mapped to `Binding` objects in

--- a/source/documentation/rdf/__index.md
+++ b/source/documentation/rdf/__index.md
@@ -162,7 +162,7 @@ are defined before use.
 **Note**
 
 Jena does not treat namespaces in a special way. A `Model` will remember any prefixes defined
-in the input RDF (see the [`PrefixMapping`](http://jena.apache.org/documentation/javadoc/jena/org/apache/jena/shared/PrefixMapping.html)
+in the input RDF (see the [`PrefixMapping`](/documentation/javadoc/jena/org/apache/jena/shared/PrefixMapping.html)
 interface; all Jena `Model` objects extend `PrefixMapping`), and the output writers which
 serialize a model to XML or Turtle will normally attempt to use prefixes to abbreviate URI's.
 However internally, a `Resource` URI is not separated into a namespace and local-name pair.
@@ -183,11 +183,11 @@ Package | Description | More information
 ------- | ----------- | ----------------
 oaj.jena.rdf.model  | The Jena core. Creating and manipulating RDF graphs. |
 oaj.riot            | Reading and Writing RDF. |
-oaj.jena.datatypes | Provides the core interfaces through which datatypes are described to Jena.| [Typed literals](http://jena.apache.org/documentation/notes/typed-literals.html)
-oaj.jena.ontology | Abstractions and convenience classes for accessing and manipulating ontologies represented in RDF. | [Ontology API](http://jena.apache.org/documentation/ontology/index.html)
+oaj.jena.datatypes | Provides the core interfaces through which datatypes are described to Jena.| [Typed literals](/documentation/notes/typed-literals.html)
+oaj.jena.ontology | Abstractions and convenience classes for accessing and manipulating ontologies represented in RDF. | [Ontology API](/documentation/ontology/index.html)
 oaj.jena.rdf.listeners  | Listening for changes to the statements in a model |
-oaj.jena.reasoner|  The reasoner subsystem is supports a range of inference engines which derive additional information from an RDF model | [Reasoner how-to](http://jena.apache.org/documentation/inference/index.html)
+oaj.jena.reasoner|  The reasoner subsystem is supports a range of inference engines which derive additional information from an RDF model | [Reasoner how-to](/documentation/inference/index.html)
 oaj.jena.shared | Common utility classes |
 oaj.jena.vocabulary | A package containing constant classes with predefined constant objects for classes and properties defined in well known vocabularies. |
 
-oaj.jena.xmloutput |   Writing RDF/XML. | [I/O index](http://jena.apache.org/documentation/io/index.html)
+oaj.jena.xmloutput |   Writing RDF/XML. | [I/O index](/documentation/io/index.html)

--- a/source/documentation/rdfconnection/__index.md
+++ b/source/documentation/rdfconnection/__index.md
@@ -48,7 +48,7 @@ in the example above):
     conn.close() ;
 
 Jena also provides a separate
-[SPARQL over JDBC driver](//jena.staging.apache.org/documentation/jdbc/index.html)
+[SPARQL over JDBC driver](/documentation/jdbc/index.html)
 library.
 
 ## Transactions
@@ -126,7 +126,7 @@ and [example
 5](https://github.com/apache/jena/blob/master/jena-rdfconnection/src/main/java/org/apache/jena/rdfconnection/examples/RDFConnectionExample5.java).
 
 There are many options, including setting HTTP headers for content types
-([javadoc](//jena.apache.org/documentation/javadoc/rdfconnection/index.html))
+([javadoc](/documentation/javadoc/rdfconnection/index.html))
 and providing detailed configuration with
 [Apache HttpComponents HttpClient](https://hc.apache.org/httpcomponents-client-ga/).
 
@@ -164,7 +164,7 @@ The file extension is used to determine the syntax.
 
 There is also a set of scripts to help do these operations from the command
 line with
-<a href="//jena.apache.org/documentation/fuseki2/soh.html">SOH</a>.
+<a href="/documentation/fuseki2/soh.html">SOH</a>.
 It is possible to write curl scripts as well.  The SPARQL Graph
 Store Protocol provides a standardised way to manage the data in a dataset.
 

--- a/source/documentation/rdfconnection/__index.md
+++ b/source/documentation/rdfconnection/__index.md
@@ -163,8 +163,7 @@ For example: load two files:
 The file extension is used to determine the syntax.
 
 There is also a set of scripts to help do these operations from the command
-line with
-<a href="/documentation/fuseki2/soh.html">SOH</a>.
+line with [SOH](/documentation/fuseki2/soh.html).
 It is possible to write curl scripts as well.  The SPARQL Graph
 Store Protocol provides a standardised way to manage the data in a dataset.
 

--- a/source/documentation/serving_data/__index.md
+++ b/source/documentation/serving_data/__index.md
@@ -6,11 +6,10 @@ slug: index
 ## See the [Fuseki2 documentation](/documentation/fuseki2/).
 
 ----
-> This page covers Fuseki1.
-> Fuseki1 is deprecated and has been retired.
-> [Fuseki2](/documentation/fuseki2/) is current.
+> This page covers Fuseki1.<br/>
+> Fuseki1 is deprecated and has been retired.<br/>
+> [Fuseki2](/documentation/fuseki2/) is current.<br/>
 > <br/>
-> The last release of Jena with this module is Jena 3.9.0.
-> See [jena-fuseki1/README.md](https://github.com/apache/jena/tree/master/fuseki1).
-> The [original documentation](fuseki1).
+> The last release of Jena with this module is Jena 3.9.0.<br/>
+> The [original documentation](/documentation/archive/serving_data/fuseki1.html).
 ----

--- a/source/documentation/shacl/__index.md
+++ b/source/documentation/shacl/__index.md
@@ -43,7 +43,7 @@ Fuseki has a new service operation `fuseki:serviceShacl`:
 </pre>
 
 This requires a "new style" endpoint declaration:  see
-"[Fuseki Endpoint Configuration](https://jena.apache.org/documentation/fuseki2/fuseki-config-endpoint.html)".
+"[Fuseki Endpoint Configuration](/documentation/fuseki2/fuseki-config-endpoint.html)".
 
 This is not installed into a dataset setup by default; a configuration file using
 `fuseki:serviceShacl` is necessary (or programmatic setup for Fuskei Main).

--- a/source/documentation/tdb/__index.md
+++ b/source/documentation/tdb/__index.md
@@ -3,12 +3,10 @@ title: TDB
 slug: index
 ---
 
-TDB is a component of
-[Jena](http://jena.apache.org/) for RDF storage
-and query.  It support the full range of Jena APIs.
-TDB can be used as a high performance RDF store on a single machine.
-This documentation describes the latest version, unless
-otherwise noted.
+TDB is a component of [Jena](https://jena.apache.org/) for RDF storage and
+query.  It support the full range of Jena APIs.  TDB can be used as a high
+performance RDF store on a single machine.  This documentation describes the
+latest version, unless otherwise noted.
 
 This is the documentation for the current standard version of TDB. 
 This is also called TDB1 to distinguish it from the next generation version

--- a/source/documentation/tdb2/__index.md
+++ b/source/documentation/tdb2/__index.md
@@ -3,11 +3,10 @@ title: TDB2
 slug: index
 ---
 
-TDB2 is a component of
-[Apache Jena](http://jena.apache.org) for RDF storage
-and query.  It support the full range of Jena APIs.
-TDB2 can be used as a high performance RDF store on a single machine.
-TDB2 can be used with Apache Jena Fuseki.
+TDB2 is a component of [Apache Jena](https://jena.apache.org) for RDF storage
+and query.  It support the full range of Jena APIs.  TDB2 can be used as a high
+performance RDF store on a single machine.  TDB2 can be used with Apache Jena
+Fuseki.
 
 TDB1 is the previous generation native storage system for Jena.
 

--- a/source/documentation/tools/schemagen-maven.md
+++ b/source/documentation/tools/schemagen-maven.md
@@ -4,8 +4,8 @@ title: Schemagen Maven
 
 # Schemagen-maven: generating Java source files from OWL and RDFS ontologies via Maven
 
-The [Apache Jena](http://jena.apache.org) command line tool
-[`schemagen`](http://jena.apache.org/documentation/tools/schemagen.html)
+The [Apache Jena](/) command line tool
+[`schemagen`](/documentation/tools/schemagen.html)
 provides an automated way of creating
 Java source code constants from ontology files in an RDF-based project. This
 can be very convenient, as it provides both a level of robustness that the
@@ -124,7 +124,7 @@ in `src/main/vocabs`:
 Options are, in general, given in the `<fileOptions>` section. A given
 `<source>` refers to one input source - one file - as named by the
 `<input>` name. The actual option names are taken from the RDF [config
-file property names](http://jena.apache.org/documentation/tools/schemagen.html),
+file property names](/documentation/tools/schemagen.html),
 omitting the namespace:
 
           <fileOptions>

--- a/source/tutorials/sparql.md
+++ b/source/tutorials/sparql.md
@@ -9,7 +9,7 @@ language through examples but does not aim to be complete.
 If you are looking for a short introduction to SPARQL and Jena try
 [Search RDF data with SPARQL](http://www.ibm.com/developerworks/xml/library/j-sparql/).  If you are looking to execute SPARQL queries in code and already known SPARQL then you likely want to read the [ARQ Documentation][1] instead.
 
-[1]: https://jena.apache.org/documentation/query/index.html
+[1]: /documentation/query/index.html
 
 SPARQL is a
 [query language](http://www.w3.org/TR/sparql11-query/) and a

--- a/source/tutorials/sparql_pt.md
+++ b/source/tutorials/sparql_pt.md
@@ -7,7 +7,7 @@ O objetivo deste tutorial é dar um curso rápido sobre SPARQL. Esse tutorial co
 Se você estiver procurando uma pequena introdução a SPARQL e Jena, experimente 
 [Search RDF data with SPARQL](http://www.ibm.com/developerworks/xml/library/j-sparql/).  Se você quer executar consultas SPARQL e já sabe como ele funciona, então você deveria ler a [ARQ Documentation][1].
 
-[1]: http://jena.apache.org/documentation/query/index.html
+[1]: /documentation/query/index.html
 
 SPARQL é uma
 [linguagem de consulta](http://www.w3.org/TR/sparql11-query/) e um


### PR DESCRIPTION
and then they work with `hugo server` on `localhost:1414`.

Left "/documentation" in URLs because it was a lot more change to what the position-relative URL would be.