### PR TITLE
Updates for using log4j2

### DIFF
--- a/source/documentation/fuseki2/fuseki-logging.md
+++ b/source/documentation/fuseki2/fuseki-logging.md
@@ -4,11 +4,11 @@ title: Fuseki Logging
 
 Fuseki logs operation details and also provides a standard NCSA request log.  
 
-Logging is via [slj4j](http://slf4j.org/) over 
-[Apache Log4J](http://logging.apache.org/log4j/).
-Logging output is controlled via log4j.
+Logging is via [SLF4J](http://slf4j.org/) over 
+[Apache Log4J2](http://logging.apache.org/log4j/2.x/), or by
+the Tomcat configuration if running the WAR file.
 
-## Server Logs
+
 
 | Full Log name                   | Usage |
 |---------------                  |-------|
@@ -19,7 +19,7 @@ Logging output is controlled via log4j.
 | org.apache.jena.fuseki.Builder  | Dataset and service build operations |
 | org.apache.jena.fuseki.Config   | Configuration                        |
 
-## NCSA request Log. 
+## NCSA request Log
 
 This log is in NCSA extended/combined log format.  
 Many web log analysers can process this format.
@@ -32,27 +32,27 @@ or reverse proxy will log access requests anyway.
 
 ## Setting logging
 
-The Fuseki engine looks for the log4j configuration as follows:
+The Fuseki engine looks for the log4j2 configuration as follows:
 
-* Use system property `log4j.configuration` if defined (as usual for log4j).
-* Use `file:log4j.properties` (current directory) if it exists
-* Use file `log4j.properties` is the directory defined by `FUSEKI_BASE`
-* Use java resource `log4j.properties` on the classpath.
-* Use java resource `org/apache/jena/fuseki/log4j.properties` on the classpath.
+* Use system property `log4j2.configurationFile` if defined ([as usual for log4j2](https://logging.apache.org/log4j/2.x/manual/configuration.html)).
+* Use `file:log4j2.properties` (current directory) if it exists
+* Use file `log4j2.properties` is the directory defined by `FUSEKI_BASE`
+* Use java resource `log4j2.properties` on the classpath.
+* Use java resource `org/apache/jena/fuseki/log4j2.properties` on the classpath.
 * Use a built-in configuration.
 
 The last step is a fallback to catch the case where Fuseki has been repackaged
 into a new WAR file and `org/apache/jena/fuseki/log4j.properties` omitted, or run from
 the base jar.  It is better to include `org/apache/jena/fuseki/log4j.properties`.
 
-The preferred customization is to use a custom `log4j.properties` file in
+The preferred customization is to use a custom `log4j2.properties` file in
 `FUSEKI_BASE`.  For the WAR file, `FUSEKI_BASE` defaults to `/etc/fuseki`
 on Linux.  For the standalone server, `FUSEKI_BASE` defaults to directory
 `run/` within the directory where the server is run.
 
 ## Default setting
 
-The [default log4j.properties](https://github.com/apache/jena/blob/master/jena-fuseki2/jena-fuseki-core/src/main/resources/org/apache/jena/fuseki/log4j.properties).
+The [default log4j2.properties](https://github.com/apache/jena/blob/master/jena-fuseki2/apache-jena-fuseki/log4j2.properties).
 
 ## Logrotate
 
@@ -76,4 +76,3 @@ It uses `copytruncate`.  This may lead to at most one broken log file line.
         # No need
         # delaycompress
     }
-

--- a/source/documentation/fuseki2/fuseki-main.md
+++ b/source/documentation/fuseki2/fuseki-main.md
@@ -103,7 +103,7 @@ then the application will also need to include jena-text in its dependencies.
 ## Logging {#logging}
 
 The application must set the logging provided for [slf4j](http://slf4j.org/).
-Apache jena provides helpers for the JDK-provided java logging and for Apache Log4j v1.
+Apache Jena provides helpers for the JDK-provided java logging and for Apache Log4j v2.
 
 Using the JDK-provided java logging:
 
@@ -117,22 +117,16 @@ and a dependency of:
       <version>1.x.y</version>
     </dependency>
 
-For Apache log4j: - this is how the full Fuseki server sets its logging:
+For Apache Log4j2: - this is how the full Fuseki server sets its logging:
 
     FusekiLogging.setLogging();
 
-and dependencies:
+and dependency:
 
     <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-log4j12</artifactId>
-      <version>1.x.y</version>
-    </dependency>
-
-    <dependency>
-      <groupId>log4j</groupId>
-      <artifactId>log4j</artifactId>
-      <version>1.x.y</version>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-slf4j-impl</artifactId>
+      <version>2.13.1</version> <!-- Many versions work -->  
     </dependency>
 
 See [Fuseki Logging](/documentation/fuseki2/fuseki-logging.html).

--- a/source/documentation/inference/__index.md
+++ b/source/documentation/inference/__index.md
@@ -606,7 +606,7 @@ slug: index
     <td width="16%">Boolean</td>
     <td width="62%">
       <div align="left">If true switches on exhaustive tracing of rule executions
-        to the log4j <i>info</i> appender.</div>
+        at the <i>INFO</i> level.</div>
     </td>
   </tr>
   <tr>
@@ -1022,7 +1022,7 @@ configuration still leaves something to be desired and will the subject of futur
     <td width="16%">boolean</td>
     <td width="62%">
       <div align="left">If true switches on exhaustive tracing of rule executions
-        to the log4j <i>info</i> appender.</div>
+        at the <i>INFO</i> level.</div>
     </td>
   </tr>
   <tr>
@@ -1626,7 +1626,7 @@ Reasoner reasoner = new GenericRuleReasoner(rules);</pre>
     <td width="23%">Boolean</td>
     <td width="51%">
       <div align="left">If true, switches on exhaustive tracing of rule executions
-        to the log4j <i>info</i> appender.</div>
+        at the <i>INFO</i> level.</div>
     </td>
   </tr>
   <tr>

--- a/source/documentation/io/rdf-input.md
+++ b/source/documentation/io/rdf-input.md
@@ -134,7 +134,7 @@ For example, to read Trig data, and set the error handler specially,
 ## Logging
 
 The parsers log to a logger called `org.apache.jena.riot`.  To avoid `WARN`
-messages, set this in log4j.properties to `ERROR`.
+messages, set this to `ERROR` in the logging system of the application.
 
 ## StreamManager and LocationMapper
     
@@ -225,7 +225,7 @@ The base URI for reading models will be the original URI, not the alternative lo
 
 ### Debugging
 
-Using log4j, set the logging level of the classes:
+Set the logging level of the classes:
 
 * org.apache.jena.riot.stream.StreamManager
 * org.apache.jena.riot.stream.LocationMapper

--- a/source/documentation/notes/file-manager.md
+++ b/source/documentation/notes/file-manager.md
@@ -110,15 +110,15 @@ original URI, not the alternative location.
 
 ### Debugging
 
-Using log4j, set the logging level of the classes:
-    org.apache.jena.util.FileManager=ALL
-    org.apache.jena.util.LocationManager=ALL
+If log4j2, set the logging level of the classes:
+
+    logger.filemanager.name        = org.apache.jena.util.FileManager
+    logger.filemanager.level       = ALL
+    logger.location-manager.name   = org.apache.jena.util.LocationManager
+    logger.location-manager.level  = ALL
 
 ### See also
 
 Javadoc:
-[FileManager](/documentation/javadoc/jena/org/apache/jena/util/FileManager.html)
-[LocationMapper](/documentation/javadoc/jena/org/apache/jena/util/LocationMapper.html)
-
-
-
+* [FileManager](/documentation/javadoc/jena/org/apache/jena/util/FileManager.html)
+* [LocationMapper](/documentation/javadoc/jena/org/apache/jena/util/LocationMapper.html)

--- a/source/documentation/query/cmds.md
+++ b/source/documentation/query/cmds.md
@@ -12,6 +12,11 @@ directories. There are ancillary scripts in the directories that
 the main commands need - see [the tools page](../tools/index.html)
 for setup details.
 
+The commands look for file `log4j2.properties` in the current directory, as well
+as the usual log4j2 initialization with property `log4j.configurationFile` and
+looking for classpath resource `log4j2.properties`; there is a default setup of
+log4j2 built-in.
+
 -   [`arq.query`](#arqquery) is the main query driver.
 
 -   [`arq.qparse`](#arqqparse) : parse and print a

--- a/source/documentation/query/explain.md
+++ b/source/documentation/query/explain.md
@@ -65,10 +65,11 @@ query execution speeds but the order of operations logged will be
 correct.
 
 The logger used is called `org.apache.jena.arq.exec`. Message are sent
-at level "info". So for log4j, the following can be set in the
-log4j.properties file:
+at level "info". So for log4j2, the following can be set in the
+`log4j2.properties` file:
 
-    log4j.logger.org.apache.jena.arq.exec=INFO
+    logger.arq-exec.name  = org.apache.jena.arq.exec
+    logger.arq-exec.level = INFO
 
 The context setting is for key (Java constant) `ARQ.symLogExec`. To set
 globally:

--- a/source/documentation/query/logging.md
+++ b/source/documentation/query/logging.md
@@ -4,8 +4,8 @@ title: ARQ - Logging
 
 ARQ uses
 [SLF4j](http://slf4j.org/)
-as the API and ships with
-[Log4J](http://logging.apache.org/log4j/) as a deployment
+as the logging API and the query and RIOT commands use
+[Log4J2](http://logging.apache.org/log4j/2.x/) as a deployment
 system.  You can use Java 1.4 logging instead.
 
 ARQ does not output any logging messages at level INFO in normal
@@ -26,43 +26,51 @@ the web application and the system directories as this can cause
 separate logging systems to be created (this may not matter).
 
 The ARQ and RIOT command line utilities look for a file
-"log4j.properties" in the current directory to control logging during
-command execution.
+"log4j2.properties" in the current directory to control logging during
+command execution. There is also a built-in configuration so no
+configuration work is required.
+
 
 Logger Names | Name | Constant | Logger | Use
 ------------ | ---- | -------- | ------ | ---
 `org.apache.jena.arq.info` | `ARQ.logInfoName` | `ARQ.getLoggerInfo()` | General information
 `org.apache.jena.arq.exec` | `ARQ.logExecName` | `ARQ.getLoggerExec()` | Execution information
 
-There is some code to cover simple situations. See the [log4j
-documentation](http://logging.apache.org/log4j/1.2/manual.html)
-for full details of log4j.
-
 The reading of `log4j.properties` from the current directory is achieved
-by a call to `org.apache.jena.atlas.logging.Log.setlog4j()`.
+by a call to `org.apache.jena.atlas.logging.Log.setlog4j2()`.
 
-Example log4j.properties file:
+Example `log4j2.properties` file:
 
-    log4j.rootLogger=INFO, stdlog
+```
+status = error
+name = PropertiesConfig
+filters = threshold
 
-    log4j.appender.stdlog=org.apache.log4j.ConsoleAppender
-    ## log4j.appender.stdlog.target=System.err
-    log4j.appender.stdlog.layout=org.apache.log4j.PatternLayout
-    log4j.appender.stdlog.layout.ConversionPattern=%d{HH:mm:ss} %-5p %-25c{1} :: %m%n
+filter.threshold.type = ThresholdFilter
+filter.threshold.level = INFO
 
-    # Execution logging
-    log4j.logger.org.apache.jena.arq.info=INFO
-    log4j.logger.org.apache.jena.arq.exec=INFO
+appender.console.type = Console
+appender.console.name = STDOUT
+appender.console.layout.type = PatternLayout
+appender.console.layout.pattern = %d{HH:mm:ss} %-5p %-15c{1} :: %m%n
 
-    # Other
-    log4j.logger.org.apache.jena=WARN
-    log4j.logger.org.apache.jena=WARN
+rootLogger.level                  = INFO
+rootLogger.appenderRef.stdout.ref = STDOUT
 
+logger.jena.name  = org.apache.jena
+logger.jena.level = INFO
+
+logger.arq-exec.name  = org.apache.jena.arq.exec
+logger.arq-exec.level = INFO
+
+logger.arq-info.name  = org.apache.jena.arq.exec
+logger.arq-info.level = INFO
+
+logger.riot.name  = org.apache.jena.riot
+logger.riot.level = INFO
+```
 A [Fuseki](../serving/data/index.html)
 server output can include [ARQ execution logging](explain.html "ARQ/Explain").
-
-Note: ARQ performs some direct control of logging in the test suite and
-depends on log4j to compile.
 
 ## Execution Logging
 
@@ -74,10 +82,11 @@ Explanatory messages are controlled by the `Explain.InfoLevel` level in
 the execution context.
 
 The logger used is called `org.apache.jena.arq.exec`. Message are sent
-at level "info". So for log4j, the following can be set in the
-log4j.properties file:
+at level "info". So for log4j2, the following can be set in the
+log4j2.properties file:
 
-    log4j.logger.org.apache.jena.arq.exec=INFO
+    logger.arq-exec.name  = org.apache.jena.arq.exec
+    logger.arq-exec.level = INFO
 
 The context setting is for key (Java constant) `ARQ.symLogExec`. To set
 globally:

--- a/source/documentation/shacl/__index.md
+++ b/source/documentation/shacl/__index.md
@@ -30,7 +30,7 @@ which writes out a text format.
 
 ## Integration with Apache Jena Fuseki
 
-Fuseki has a new service operation `fuseki:serviceShacl`:
+Fuseki has a new service operation `fuseki:shacl`:
 
 <pre>
 &lt;#serviceInMemoryShacl&gt; rdf:type fuseki:Service ;
@@ -46,7 +46,11 @@ This requires a "new style" endpoint declaration:  see
 "[Fuseki Endpoint Configuration](/documentation/fuseki2/fuseki-config-endpoint.html)".
 
 This is not installed into a dataset setup by default; a configuration file using
-`fuseki:serviceShacl` is necessary (or programmatic setup for Fuseki Main).
+```
+fuseki:endpoint [ fuseki:operation fuseki:shacl ;
+                  fuseki:name "shacl" ];
+```
+is necessary (or programmatic setup for Fuseki Main).
 
 The service accepts a shapes graph posted as RDF to <tt>/<i>ds</i>/shacl</tt> with
 content negotiation.
@@ -66,7 +70,7 @@ Validate with shapes in `fu-shapes.ttl` and get back a validation report:
 
     curl -XPOST --data-binary @fu-shapes.ttl  \  
          --header 'Content-type: text/turtle' \  
-         'http://localhost:3030/ds/shacl?graph-default'
+         'http://localhost:3030/ds/shacl?graph=default'
 
 ## API
 

--- a/source/documentation/tdb/configuration.md
+++ b/source/documentation/tdb/configuration.md
@@ -102,7 +102,7 @@ Configuration Symbols
 
 Symbol | Java Constant | Effect | Default
 ------ | ------------- | ------ | -------
-`tdb:logExec` | `TDB.symLogExec` | Log execution of BGPs. Set to "true" to enable. Must also enable the logger "org.apache.jena.tdb.exec". e.g. log4j.properties `log4j.logger.org.apache.jena.tdb.exec=INFO` | unset
+`tdb:logExec` | `TDB.symLogExec` | Log execution of BGPs. Set to "true" to enable. Must also enable the logger "org.apache.jena.tdb.exec". | unset
 `tdb:unionDefaultGraph` | `TDB.symUnionDefaultGraph` | Query patterns on the default graph match against the union of the named graphs. | unset
 `tdb:fileMode` | `SystemTDB.fileMode` | Force use of memory mapped files (`"mapped"`) or direct file caching (`"direct"`). See discussion of TDB on 32 or 64 bit hardware, especially limitations of memory mapped files on 32 bit Java. | Set by the system based on 32 or 64 bit java.
 

--- a/source/documentation/tdb/optimizer.md
+++ b/source/documentation/tdb/optimizer.md
@@ -35,6 +35,12 @@ properties.
     -   [Generating statistics for Union Graphs](#generating-statistics-for-union-graphs)
 -   [Writing Rules](#writing-rules)
 
+The commands look for file `log4j2.properties` in the current directory, as well
+as the usual log4j2 initialization with property `log4j.configurationFile` and
+looking for classpath resource `log4j2.properties`; there is a default setup of
+log4j2 built-in.
+
+
 ## Quickstart
 
 This section provides a practical how-to.
@@ -90,22 +96,21 @@ TDB can optionally log query execution details. This is controlled
 by two setting: the logging level and a context setting. Having two
 setting means it is possible to log some queries and not others.
 
-The logger used is called `org.apache.jena.arq.exec`. Message are
-sent at level "info". So for log4j, the following can be set in the
-log4j.properties file:
+The logger used is called `org.apache.jena.arq.exec`. Messages are
+sent at level "INFO". So for log4j2, the following can be set in the
+log4j2.properties file:
 
     # Execution logging
-    log4j.logger.org.apache.jena.arq.info=WARN
-    log4j.logger.org.apache.jena.arq.exec=WARN
+    logger.arq-exec.name  = org.apache.jena.arq.exec
+    logger.arq-exec.level = INFO
 
-In versions of TDB before 0.8.7, this is:
-
-    log4j.logger.org.apache.jena.tdb.exec=INFO
+    logger.arq-info.name  = org.apache.jena.arq.exec
+    logger.arq-info.level = INFO
 
 The context setting is for key (Java constant) `ARQ.symLogExec`. To
 set globally:
 
-    TDB.getContext().set(ARQ.symLogExec,true) ;
+    ARQ.getContext().set(ARQ.symLogExec,true) ;
 
 and it may also be set on an individual query execution using it's
 local context.
@@ -115,15 +120,9 @@ local context.
         ResultSet rs = qExec.execSelect() ;
      }
 
-Use `TDB.symLogExec` for versions prior to 0.8.8.
-
 On the command line:
 
-     tdbquery --set tdb:logExec=true --file queryfile
-
-TDB version 0.8.3 provides more fine-grained logging controls.
-Instead of "true", which sets all levels, the following can be
-used:
+     tdbquery --set arq:logExec=true --file queryfile
 
 ## Explanation Levels
 
@@ -156,16 +155,31 @@ we can include the `--explain` parameter to the command
 and increase the logging levels, in order to output more information about 
 the query execution.
 
-    # log4j.properties
+    # log4j2.properties
     log4j.rootLogger=INFO, stdlog
     log4j.appender.stdlog=org.apache.log4j.ConsoleAppender
     log4j.appender.stdlog.layout=org.apache.log4j.PatternLayout
     log4j.appender.stdlog.layout.ConversionPattern=%d{HH:mm:ss} %-5p %-25c{1} :: %m%n
-    # the query execution logger
-    log4j.logger.org.apache.jena.arq.exec=INFO
 
-It is important to create a `log4j.logger.org.apache.jena.arq.exec` logger, 
-as otherwise the command won't output the query execution details.
+    status = error
+    name = PropertiesConfig
+    filters = threshold
+    filter.threshold.type = ThresholdFilter
+    filter.threshold.level = INFO
+
+    appender.console.type = Console
+    appender.console.name = STDOUT
+    appender.console.layout.type = PatternLayout
+    appender.console.layout.pattern = %d{HH:mm:ss} %-5p %-15c{1} :: %m%n
+
+    rootLogger.level                  = INFO
+    rootLogger.appenderRef.stdout.ref = STDOUT
+
+    # the query execution logger
+
+    # Execution logging
+    logger.arq-exec.name  = org.apache.jena.arq.exec
+    logger.arq-exec.level = INFO
 
 The command output will be similar to this one.
 


### PR DESCRIPTION
For 3.15.0.

Update pages that mention logging with log4j to be log4j2.
