### PR TITLE
Added Jenkinsfile to put deployment configuration in version control

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,112 @@
+#!groovy
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+pipeline {
+    agent {
+        // https://cwiki.apache.org/confluence/display/INFRA/Jenkins+node+labels
+        label 'git-websites'
+    }
+   
+    environment {
+        HUGO_VERSION = '0.66.0'
+        DEPLOY_BRANCH = 'asf-site'
+    }
+
+    stages {
+        stage('Prepare') {
+            steps {
+                script {
+                    // Capture last commit hash for final commit message
+                    env.LAST_SHA = sh(script:'git log -n 1 --pretty=format:\'%H\'', returnStdout: true).trim()
+
+                    // Setup Hugo
+                    env.HUGO_DIR = sh(script:'mktemp -d', returnStdout: true).trim()
+                    sh """
+                        mkdir -p ${env.HUGO_DIR}/bin
+                        cd ${env.HUGO_DIR}
+                        wget --no-verbose -O hugo.tar.gz https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_Linux-64bit.tar.gz
+                        tar xfzv hugo.tar.gz
+                        mv hugo ${env.HUGO_DIR}/bin/
+                    """
+
+                    // Setup directory structure for generated content
+                    env.TMP_DIR = sh(script:'mktemp -d', returnStdout: true).trim()
+                    env.OUT_DIR = "${env.TMP_DIR}/content"
+                    sh "mkdir -p ${env.OUT_DIR}"
+                    
+                }
+            }
+        }
+        stage('Build') {
+            steps {
+                script {
+                    withEnv(["PATH+HUGO=${env.HUGO_DIR}/bin"]) {
+                        sh "hugo --destination ${env.OUT_DIR}"
+                    }
+                }
+            }
+        }
+        stage('Deploy') {
+            when {
+                anyOf {
+                    branch 'master'
+                }
+            }
+            steps {
+                script {
+                    // Checkout branch with generated content
+                    sh """
+                        git checkout ${DEPLOY_BRANCH}
+                        git pull origin ${DEPLOY_BRANCH}
+                    """
+                    
+                    // Remove the content of the target branch and replace it with the content of the temp folder
+                    sh """
+                        rm -rf ${WORKSPACE}/content
+                        git rm -r --cached content/*
+                        mkdir -p ${WORKSPACE}/content
+                        cp -rT ${env.TMP_DIR}/* ${WORKSPACE}/content
+                    """
+                    
+                    // Commit the changes to the target branch
+                    env.COMMIT_MESSAGE = "Updated site from ${BRANCH_NAME} (${env.LAST_SHA})"
+                    sh """
+                        git add -A
+                        git commit -m "${env.COMMIT_MESSAGE}" | true
+                    """
+                    
+                    // Push the generated content for deployment
+                    sh "git push -u origin ${DEPLOY_BRANCH}"
+                }
+            }
+        }
+    }
+    
+    post {
+        always {
+            script {
+                sh """
+                    rm -rf ${env.HUGO_DIR}
+                    rm -rf ${env.TMP_DIR}
+                """
+            }
+            deleteDir() /* clean up our workspace */
+        }
+    }
+}
+


### PR DESCRIPTION
This puts the job configuration for deploying the Jena website in version control.

It is created as multi-branch pipeline so that branches other than master will be tested as well (whether they build using Hugo). Deployment (copy from master -> asf-site) only happens on the 'master' branch.

---

Steps to do to correctly setup the Jenkins job:
- Create a new multibranch pipeline (e.g. 'site').
- Set the gitbox url -> `https://gitbox.apache.org/repos/asf/jena-site.git` and use the `jenkins (master pub key)` credentials.
- In the 'Scan Multibranch Pipeline Triggers' check the 'Periodically if not otherwise run' checkbox and enter a sane value (e.g. 15 minutes). This is needed because webhooks are not delivered to ci-builds (yet).
- Save the job and click the 'Scan Multibranch Pipeline Now' button to trigger an initial scan.

Output should be similar to:
- https://ci-builds.apache.org/job/Celix/job/site/
- https://ci-builds.apache.org/job/Celix/job/site/job/master/8/console

---

/cc @afs 