### PR TITLE
Fix YAML title

### DIFF
--- a/source/documentation/fuseki2/fuseki-docker.md
+++ b/source/documentation/fuseki2/fuseki-docker.md
@@ -1,5 +1,5 @@
 ---
-title: Fuseki : Docker Tools
+title: "Fuseki : Docker Tools"
 ---
 
 The [jena-fuseki-docker package](https://repo1.maven.org/maven2/org/apache/jena/jena-fuseki-docker/)

--- a/source/documentation/fuseki2/fuseki-embedded.md
+++ b/source/documentation/fuseki2/fuseki-embedded.md
@@ -1,5 +1,5 @@
 ---
-title: Fuseki : Emdedded Server
+title: "Fuseki : Emdedded Server"
 ---
 
 Fuseki can be run within a larger JVM application as an embedded triplestore.

--- a/source/documentation/fuseki2/fuseki-main.md
+++ b/source/documentation/fuseki2/fuseki-main.md
@@ -1,5 +1,5 @@
 ---
-title: Fuseki : Main Server
+title: "Fuseki : Main Server"
 ---
 
 Fuseki main is a packaging of Fuseki as a triple store without a UI for administration.


### PR DESCRIPTION
Tried building the site with `hugo` and got:

```
Error: Error building site: "/home/kinow/Development/java/jena/jena-site/source/documentation/fuseki2/fuseki-docker.md:2:1": failed to unmarshal YAML: yaml: mapping values are not allowed in this context

```

Another file in the same directory has a title similar with the "colon" character, but wrapped in quotes. So I just used the same approach in the files failing, until I got:

```bash
$ hugo

                   | EN   
-------------------+------
  Pages            | 233  
  Paginator pages  |   0  
  Non-page files   |   0  
  Static files     | 135  
  Processed images |   0  
  Aliases          |   0  
  Sitemaps         |   1  
  Cleaned          |   0 
```