### PR TITLE
Make the output column name consistent with query.

### DIFF
--- a/source/tutorials/sparql_basic_patterns.md
+++ b/source/tutorials/sparql_basic_patterns.md
@@ -24,7 +24,7 @@ This has 4 solutions, one for each VCARD name property triples in
 the data source
 
     ----------------------------------------------------
-    | x                                | name          |
+    | x                                | fname         |
     ====================================================
     | <http://somewhere/RebeccaSmith/> | "Becky Smith" |
     | <http://somewhere/SarahJones/>   | "Sarah Jones" |


### PR DESCRIPTION
The query specifies `fname`, while the example output uses `name`. My understanding is that this output column should be the same as what's specified in the query.