### PR TITLE
Fuseki embedded server: fix first example

### DIFF
--- a/source/documentation/fuseki2/fuseki-embedded.md
+++ b/source/documentation/fuseki2/fuseki-embedded.md
@@ -104,7 +104,7 @@ port for Fuseki running as a standalone server or as a webapp application.
 Create a server on port 3330, that provides the default set of endpoints for an RDF
 dataset that can be updated via HTTP.
 
-    DatasetGraph ds = DatasetFactory.createTxnMem() ;
+    Dataset ds = DatasetFactory.createTxnMem() ;
     FusekiServer server = FusekiServer.create()
         .add("/ds", ds)
         .build() ;


### PR DESCRIPTION
`DatasetFactory::createTxnMem` returns `Dataset` not `DatasetGraph`.
As `org.apache.jena.fuseki.main.FusekiServer.Builder::add(String, Dataset)` also exists, the following code is still valid.