### PR TITLE
use shortcut style for geostandard link

### DIFF
--- a/source/documentation/geosparql/__index.md
+++ b/source/documentation/geosparql/__index.md
@@ -8,7 +8,7 @@ An implementation of GeoSPARQL 1.0 standard for SPARQL query or API.
 An [integration with Fuseki](geosparql-fuseki) is available but attention should be paid to the contents of this page to understand supported features.
 
 ## Features
-This implementation follows the 11-052r4 OGC GeoSPARQL standard (https://www.ogc.org/standards/geosparql).
+This implementation follows the 11-052r4 OGC GeoSPARQL standard (<https://www.ogc.org/standards/geosparql>).
 The implementation is pure Java and does not require any set-up or configuration of any third party relational databases and geospatial extensions.
 
 It implements the six Conformance Classes described in the GeoSPARQL document:

--- a/source/documentation/geosparql/__index.md
+++ b/source/documentation/geosparql/__index.md
@@ -31,7 +31,7 @@ Indexing and caching of spatial objects and relations is performed _on-demand_ d
 Therefore, set-up delays should be minimal. Spatial indexing is available based on the _STRtree_ from the JTS library. The _STRtree_ is readonly once built and contributions of a _QuadTree_ implementation are welcome.
 
 Benchmarking of the implementation against Strabon and Parliament has found it to be comparable or quicker.
-The benchmarking used was the Geographical query and dataset (http://geographica.di.uoa.gr/).
+The benchmarking used was the Geographical query and dataset (<http://geographica.di.uoa.gr/>).
 
 ## Additional Features
 The following additional features are also provided:
@@ -40,7 +40,7 @@ The following additional features are also provided:
 * Conversion between EPSG spatial/coordinate reference systems is applied automatically. Therefore, mixed datasets or querying can be applied. This is reliance upon local installation of Apache SIS EPSG dataset, see __Key Dependencies__.
 * Units of measure are automatically converted to the appropriate units for the coordinate reference system.
 * Geometry, transformation and spatial relation results are stored in persistent and configurable time-limited caches to improve response times and reduce recalculations.
-* Dataset conversion between serialisations and spatial/coordinate reference systems. Tabular data can also be loaded, see RDF Tables project (https://github.com/galbiston/rdf-tables).
+* Dataset conversion between serialisations and spatial/coordinate reference systems. Tabular data can also be loaded, see RDF Tables project (<https://github.com/galbiston/rdf-tables>).
 * Functions to test Geometry properties directly on Geometry Literals have been included for convenience.
 
 ## Getting Started


### PR DESCRIPTION
The url in parens is converted to a `<a href` link giving 404 (ending parens becomes part of the link).

Not sure if the documentation cms supports the markdown shortcut for autolinks described in https://stackoverflow.com/questions/24887301/is-there-a-syntax-for-links-with-no-text-in-markdown