### PR TITLE
Add .asf.yaml for website publishing

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -1,0 +1,2 @@
+publish:
+  whoami: asf-site


### PR DESCRIPTION
Per ASF Infrastructure announcement (https://lists.apache.org/thread.html/raf30ca1c77b81bc8c535c53b7aff38e1ff3c755ce84f4a40a6d8ad53%40%3Cusers.infra.apache.org%3E) today (requires ASF login) git based pub sub for website publishing is being deprecated in favour of project self management via the `.asf.yaml` file as described at https://cwiki.apache.org/confluence/display/INFRA/Git+-+.asf.yaml+features#Git.asf.yamlfeatures-WebSiteDeploymentServiceforGitRepositories

This PR adds a `.asf.yaml` file to the `asf-site` branch (remember these files are branch specific) so that whenever the `asf-site` branch gets updated it will be published as our website.