### PR TITLE
Set up .asf.yaml for Javadoc self-publishing

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -1,0 +1,3 @@
+publish:
+  whoami: javadoc
+  subdir: documentation/javadoc


### PR DESCRIPTION
Companion PR to PR #56, since we publish content from two branches currently with Git Pub Sub we need to have appropriate `.asf.yaml` files on both branches (again it's a branch specific file).

The file provided here publishes just this branch into the `documentation/javadoc` directory of our site