### PR TITLE
Correct Javadoc .asf.yaml publishing

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -1,6 +1,6 @@
 publish:
   whoami: javadoc
-  subdir: documentation/javadoc
+  subdir: content/documentation/javadoc
 
 staging:
   profile: ~


### PR DESCRIPTION
The subdir path needs to be the full path in the destination branch which is not the same as the path as it appears in the final website i.e. the leading content/ was missing

Note that I verified this was the case by setting up a staging profile and you can see that this is working at https://jena.staged.apache.org/documentation/javadoc/jena/index.html