### PR TITLE
ASF CDN for downloads; remove mirrors script

### DIFF
--- a/source/download/__index.md
+++ b/source/download/__index.md
@@ -19,6 +19,7 @@ You may [verify the authenticity of artifacts](https://www.apache.org/info/verif
 The binary distribution of Fuseki (this includes both the standalone and
 WAR file packaging):
 
+
 | Jena Fuseki  | SHA512 | Signature |
 | ------------ | :----: | :-------: |
 | <a href="https://dlcdn.apache.org/jena/binaries/apache-jena-fuseki-4.2.0.tar.gz">apache-jena-fuseki-4.2.0.tar.gz</a> | [SHA512](https://downloads.apache.org/jena/binaries/apache-jena-fuseki-4.2.0.tar.gz.sha512) | [PGP](https://downloads.apache.org/jena/binaries/apache-jena-fuseki-4.2.0.tar.gz.asc) |
@@ -31,6 +32,7 @@ Source release: this forms the official release of Apache Jena. All binaries art
 | ------------ | :----: | :-------: |
 |<a href="https://dlcdn.apache.org/jena/source/jena-4.2.0-source-release.zip">jena-4.2.0-source-release.zip</a> | [SHA512](https://downloads.apache.org/jena/source/jena-4.2.0-source-release.zip.sha512) | [PGP](https://downloads.apache.org/jena/source/jena-4.2.0-source-release.zip.asc) |
 
+<p>&nbsp;</p>
 The binary distribution of libraries contains the APIs, SPARQL engine, the TDB native RDF database and a variety of command line scripts and tools for working with these systems.
 
 | Jena libraries | SHA512 | Signature |
@@ -61,7 +63,7 @@ The development codebase is available from git.
 
 [https://gitbox.apache.org/repos/asf?p=jena.git](https://gitbox.apache.org/repos/asf?p=jena.git)
 
-This is also avilable on github:
+This is also available on github:
 
 [https://github.com/apache/jena](https://github.com/apache/jena)
 

--- a/source/download/__index.md
+++ b/source/download/__index.md
@@ -14,34 +14,6 @@ Jena jars are [available from Maven](maven.html).
 
 You may [verify the authenticity of artifacts](https://www.apache.org/info/verification.html) below by using the [PGP KEYS](https://downloads.apache.org/jena/KEYS) file.
 
-## Download Mirrors
-
-<p>[if-any logo]
-<a href="[link]">
-  <img align="right" src="[logo]" border="0" />
-</a>[end]
-The currently selected mirror is <b>[preferred]</b>.  If you encounter a problem with this mirror, please select another mirror.  If all
-mirrors are failing, there are <i>backup</i> mirrors (at the end of the mirrors list) that should be available.</p>
-
-<form action="[location]" method="get" id="SelectMirror">
-Other mirrors: <select name="Preferred">
-[if-any http]
-  [for http]<option value="[http]">[http]</option>[end]
-[end]
-
-[if-any ftp]
-  [for ftp]<option value="[ftp]">[ftp]</option>[end]
-[end]
-[if-any backup]
-  [for backup]<option value="[backup]">[backup]
-  (backup)</option>[end]
-[end]
-</select>
-<input type="submit" value="Change" />
-</form>
-
-You may also consult the [complete list of mirrors](https://www.apache.org/mirrors/)
-
 ### Apache Jena Distibutions
 
 The binary distribution of Fuseki (this includes both the standalone and
@@ -49,22 +21,22 @@ WAR file packaging):
 
 | Jena Fuseki  | SHA512 | Signature |
 | ------------ | :----: | :-------: |
-| <a href="[preferred]jena/binaries/apache-jena-fuseki-4.2.0.tar.gz">apache-jena-fuseki-4.2.0.tar.gz</a> | [SHA512](https://downloads.apache.org/jena/binaries/apache-jena-fuseki-4.2.0.tar.gz.sha512) | [PGP](https://downloads.apache.org/jena/binaries/apache-jena-fuseki-4.2.0.tar.gz.asc) |
-| <a href="[preferred]jena/binaries/apache-jena-fuseki-4.2.0.zip">apache-jena-fuseki-4.2.0.zip</a> | [SHA512](https://downloads.apache.org/jena/binaries/apache-jena-fuseki-4.2.0.zip.sha512) | [PGP](https://downloads.apache.org/jena/binaries/apache-jena-fuseki-4.2.0.zip.asc) |
+| <a href="https://dlcdn.apache.org/jena/binaries/apache-jena-fuseki-4.2.0.tar.gz">apache-jena-fuseki-4.2.0.tar.gz</a> | [SHA512](https://downloads.apache.org/jena/binaries/apache-jena-fuseki-4.2.0.tar.gz.sha512) | [PGP](https://downloads.apache.org/jena/binaries/apache-jena-fuseki-4.2.0.tar.gz.asc) |
+| <a href="https://dlcdn.apache.org/jena/binaries/apache-jena-fuseki-4.2.0.zip">apache-jena-fuseki-4.2.0.zip</a> | [SHA512](https://downloads.apache.org/jena/binaries/apache-jena-fuseki-4.2.0.zip.sha512) | [PGP](https://downloads.apache.org/jena/binaries/apache-jena-fuseki-4.2.0.zip.asc) |
 
 <p>&nbsp;</p>
 Source release: this forms the official release of Apache Jena. All binaries artifacts and maven binaries correspond to this source.
 
 | Apache Jena Release | SHA512 | Signature |
 | ------------ | :----: | :-------: |
-|<a href="[preferred]jena/source/jena-4.2.0-source-release.zip">jena-4.2.0-source-release.zip</a> | [SHA512](https://downloads.apache.org/jena/source/jena-4.2.0-source-release.zip.sha512) | [PGP](https://downloads.apache.org/jena/source/jena-4.2.0-source-release.zip.asc) |
+|<a href="https://dlcdn.apache.org/jena/source/jena-4.2.0-source-release.zip">jena-4.2.0-source-release.zip</a> | [SHA512](https://downloads.apache.org/jena/source/jena-4.2.0-source-release.zip.sha512) | [PGP](https://downloads.apache.org/jena/source/jena-4.2.0-source-release.zip.asc) |
 
 The binary distribution of libraries contains the APIs, SPARQL engine, the TDB native RDF database and a variety of command line scripts and tools for working with these systems.
 
 | Jena libraries | SHA512 | Signature |
 | ------------ | :----: | :-------: |
-|<a href="[preferred]jena/binaries/apache-jena-4.2.0.tar.gz">apache-jena-4.2.0.tar.gz</a> | [SHA512](https://downloads.apache.org/jena/binaries/apache-jena-4.2.0.tar.gz.sha512) | [PGP](https://downloads.apache.org/jena/binaries/apache-jena-4.2.0.tar.gz.asc) |
-| <a href="[preferred]jena/binaries/apache-jena-4.2.0.zip">apache-jena-4.2.0.zip</a> | [SHA512](https://downloads.apache.org/jena/binaries/apache-jena-4.2.0.zip.sha512) | [PGP](https://downloads.apache.org/jena/binaries/apache-jena-4.2.0.zip.asc) |
+|<a href="https://dlcdn.apache.org/jena/binaries/apache-jena-4.2.0.tar.gz">apache-jena-4.2.0.tar.gz</a> | [SHA512](https://downloads.apache.org/jena/binaries/apache-jena-4.2.0.tar.gz.sha512) | [PGP](https://downloads.apache.org/jena/binaries/apache-jena-4.2.0.tar.gz.asc) |
+| <a href="https://dlcdn.apache.org/jena/binaries/apache-jena-4.2.0.zip">apache-jena-4.2.0.zip</a> | [SHA512](https://downloads.apache.org/jena/binaries/apache-jena-4.2.0.zip.sha512) | [PGP](https://downloads.apache.org/jena/binaries/apache-jena-4.2.0.zip.asc) |
 
 ### Individual Modules
 

--- a/static/download/.htaccess
+++ b/static/download/.htaccess
@@ -1,3 +1,0 @@
-DirectoryIndex index.cgi
-RewriteBase  /download/
-RewriteRule  ^index\.html$      index.cgi

--- a/static/download/index.cgi
+++ b/static/download/index.cgi
@@ -1,3 +1,0 @@
-#!/bin/sh
-# Wrapper around the standard mirrors.cgi script
-exec /www/www.apache.org/dyn/mirrors/mirrors.cgi $*


### PR DESCRIPTION
https://fossforce.com/2021/10/apache-foundation-moves-from-mirrors-to-a-cdn-to-distribute-software/

The script used to dynamically build the download page has started listing only one mirror - https\://dlcdn.apache.org/

This PR removes the mirror support code and uses fixed URLs https\://dlcdn.apache.org/jena/...

(The PGP and checksums remain on https\://downloads.apache.org/jena/)