### PR TITLE
JENA-2181: Notes on using alternative compression

### DIFF
--- a/source/documentation/io/__index.md
+++ b/source/documentation/io/__index.md
@@ -73,7 +73,7 @@ compressed. The file name is examined for an inner extension. For
 example, `.nt.gz` is gzip compressed N-Triples.
 
 Jena does not support all possible compression formats itself, only
-GZip, BZip2 and Snappy are supported directly.  If you want to use an 
+GZip and BZip2 are supported directly.  If you want to use an 
 alternative compression format you can do so by piping the output of the
 relevant decompression utility into one of Jena's commands e.g.
 

--- a/source/documentation/io/__index.md
+++ b/source/documentation/io/__index.md
@@ -72,6 +72,13 @@ In addition, if the extension is `.gz` the file is assumed to be gzip
 compressed. The file name is examined for an inner extension. For
 example, `.nt.gz` is gzip compressed N-Triples.
 
+Jena does not support all possible compression formats itself, only
+GZip, BZip2 and Snappy are supported directly.  If you want to use an 
+alternative compression format you can do so by piping the output of the
+relevant decompression utility into one of Jena's commands e.g.
+
+    zstd -d < FILE.nq.zst | riot --syntax NQ ...
+
 These scripts call java programs in the `riotcmd` package. For example:
 
     java -cp ... riotcmd.riot file.ttl

--- a/source/documentation/io/streaming-io.md
+++ b/source/documentation/io/streaming-io.md
@@ -16,9 +16,9 @@ to such files takes this into account, including looking for the other file
 extension.  `data.nt.gz` is parsed as a gzip-compressed N-Triples file.
 
 Jena does not support all possible compression formats itself, only
-GZip, BZip2 and Snappy are supported directly.  If you want to use an 
+GZip and BZip2 are supported directly.  If you want to use an 
 alternative compression format you can do so by adding suitable dependencies
-yourself into your project and passing a suitable `InputStream`/`OutputStream` 
+into your project and passing an appropriate `InputStream`/`OutputStream` 
 implementation to Jena code e.g.
 
     InputStream input =  new ZstdCompressorInputStream(....);

--- a/source/documentation/io/streaming-io.md
+++ b/source/documentation/io/streaming-io.md
@@ -15,6 +15,15 @@ Files ending in `.gz` are assumed to be gzip-compressed. Input and output
 to such files takes this into account, including looking for the other file
 extension.  `data.nt.gz` is parsed as a gzip-compressed N-Triples file.
 
+Jena does not support all possible compression formats itself, only
+GZip, BZip2 and Snappy are supported directly.  If you want to use an 
+alternative compression format you can do so by adding suitable dependencies
+yourself into your project and passing a suitable `InputStream`/`OutputStream` 
+implementation to Jena code e.g.
+
+    InputStream input =  new ZstdCompressorInputStream(....);
+    RDFParser.source(input).lang(Lang.NQ).parse(graph);
+
 ## StreamRDF
 
 The central abstraction is 


### PR DESCRIPTION
Show how Jena can be used with alternative compression formats beyond those it supports natively

As discussed in apache/jena#1089 may be better to document how to use alternative compression formats rather than adding direct support for them