### PR TITLE
Add title to Home

### DIFF
--- a/source/_index.md
+++ b/source/_index.md
@@ -1,5 +1,5 @@
 ---
-title: 
+title: Home
 ---
 
 <div class="jumbotron">


### PR DESCRIPTION
Noticed the home page of Jena shows just a dash, with a missing title.

![image](https://user-images.githubusercontent.com/304786/158114142-61bb4588-6a80-4a2e-9260-e146043ef20a.png)

This small change is just to add the title (used the same text as the link).

![image](https://user-images.githubusercontent.com/304786/158114177-264fccf7-4465-4480-bf04-5891c3c651d9.png)
