### PR TITLE
Make the menu more alphabetical

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -61,52 +61,53 @@
                     <ul class="dropdown-menu">
                         <li class="dropdown-header">Tutorials</li>
                         <li><a href="/tutorials/index.html">Overview</a></li>
+                        <li><a href="/documentation/fuseki2/index.html">Fuseki Triplestore</a></li>
+                        <li><a href="/documentation/notes/index.html">How-To's</a></li>
+                        <li><a href="/documentation/query/manipulating_sparql_using_arq.html">Manipulating SPARQL using ARQ</a></li>
                         <li><a href="/tutorials/rdf_api.html">RDF core API tutorial</a></li>
                         <li><a href="/tutorials/sparql.html">SPARQL tutorial</a></li>
-                        <li><a href="/documentation/query/manipulating_sparql_using_arq.html">Manipulating SPARQL using ARQ</a></li>
                         <li><a href="/tutorials/using_jena_with_eclipse.html">Using Jena with Eclipse</a></li>
-                        <li><a href="/documentation/notes/index.html">How-To's</a></li>
                         <li class="divider"></li>
                         <li class="dropdown-header">References</li>
                         <li><a href="/documentation/index.html">Overview</a></li>
-                        <li><a href="/documentation/javadoc.html">Javadoc</a></li>
-                        <li><a href="/documentation/rdf/index.html">RDF API</a></li>
-                        <li><a href="/documentation/io/">RDF I/O</a></li>
-                        <li><a href="/documentation/fuseki2/index.html">Fuseki</a></li>
                         <li><a href="/documentation/query/index.html">ARQ (SPARQL)</a></li>
-                        <li><a href="/documentation/rdfconnection/">RDF Connection - SPARQL API</a></li>
+                        <li><a href="/documentation/assembler/index.html">Assembler</a></li>
+                        <li><a href="/documentation/tools/index.html">Command-line tools</a></li>
                         <li><a href="/documentation/rdfs/">Data with RDFS Inferencing</a></li>
+                        <li><a href="/documentation/geosparql/index.html">GeoSPARQL</a></li>
+                        <li><a href="/documentation/inference/index.html">Inference API</a></li>
+                        <li><a href="/documentation/javadoc.html">Javadoc</a></li>
+                        <li><a href="/documentation/ontology/">Ontology API</a></li>
+                        <li><a href="/documentation/permissions/index.html">Permissions</a></li>
+                        <li><a href="/documentation/extras/querybuilder/index.html">Query Builder</a></li>
+                        <li><a href="/documentation/rdf/index.html">RDF API</a></li>
+                        <li><a href="/documentation/rdfconnection/">RDF Connection - SPARQL API</a></li>
+                        <li><a href="/documentation/io/">RDF I/O</a></li>
+                        <li><a href="/documentation/rdfstar/index.html">RDF-star</a></li>
+                        <li><a href="/documentation/shacl/index.html">SHACL</a></li>
+                        <li><a href="/documentation/shex/index.html">ShEx</a></li>
+                        <li><a href="/documentation/jdbc/index.html">SPARQL over JDBC</a></li>
                         <li><a href="/documentation/tdb/index.html">TDB</a></li>
                         <li><a href="/documentation/tdb2/index.html">TDB2</a></li>
                         <li><a href="/documentation/query/text-query.html">Text Search</a></li>
-                        <li><a href="/documentation/shacl/index.html">SHACL</a></li>
-                        <li><a href="/documentation/shex/index.html">ShEx</a></li>
-                        <li><a href="/documentation/rdfstar/index.html">RDF-star</a></li>
-                        <li><a href="/documentation/tools/index.html">Command-line tools</a></li>
-                        <li><a href="/documentation/jdbc/index.html">SPARQL over JDBC</a></li>
-                        <li><a href="/documentation/permissions/index.html">Permissions</a></li>
-                        <li><a href="/documentation/assembler/index.html">Assembler</a></li>
-                        <li><a href="/documentation/ontology/">Ontology API</a></li>
-                        <li><a href="/documentation/inference/index.html">Inference API</a></li>
-                        <li><a href="/documentation/extras/querybuilder/index.html">Query Builder</a></li>
                     </ul>
                 </li>
 
                 <li class="drop down">
                     <a href="#" class="dropdown-toggle" data-toggle="dropdown"><span class="glyphicon glyphicon-book"></span> Javadoc <b class="caret"></b></a>
                     <ul class="dropdown-menu">
-                        <li><a href="/documentation/javadoc/jena/">Jena Core</a></li>
-                        <li><a href="/documentation/javadoc/arq/">ARQ</a></li>
-                        <li><a href="/documentation/javadoc/tdb/">TDB</a></li>
-                        <li><a href="/documentation/javadoc/fuseki2/">Fuseki</a></li>
-                        <li><a href="/documentation/javadoc_elephas.html">Elephas</a></li>
-                        <li><a href="/documentation/javadoc/text/">Text Search</a></li>
-                        <li><a href="/documentation/javadoc/shacl/">SHACL</a></li>
-                        <li><a href="/documentation/javadoc/geosparql/">GeoSPARQL</a></li>
-                        <li><a href="/documentation/javadoc/permissions/">Permissions</a></li>
-                        <li><a href="/documentation/javadoc/jdbc/">JDBC</a></li>
-                        <li><a href="/documentation/javadoc/extras/querybuilder/">Query Builder</a></li>
                         <li><a href="/documentation/javadoc.html">All Javadoc</a></li>
+                        <li><a href="/documentation/javadoc/arq/">ARQ</a></li>
+                        <li><a href="/documentation/javadoc_elephas.html">Elephas</a></li>
+                        <li><a href="/documentation/javadoc/fuseki2/">Fuseki</a></li>
+                        <li><a href="/documentation/javadoc/geosparql/">GeoSPARQL</a></li>
+                        <li><a href="/documentation/javadoc/jdbc/">JDBC</a></li>
+                        <li><a href="/documentation/javadoc/jena/">Jena Core</a></li>
+                        <li><a href="/documentation/javadoc/permissions/">Permissions</a></li>
+                        <li><a href="/documentation/javadoc/extras/querybuilder/">Query Builder</a></li>
+                        <li><a href="/documentation/javadoc/shacl/">SHACL</a></li>
+                        <li><a href="/documentation/javadoc/tdb/">TDB</a></li>
+                        <li><a href="/documentation/javadoc/text/">Text Search</a></li>
                     </ul>
                 </li>
 
@@ -120,18 +121,18 @@
                         <li class="divider"></li>
                         <li class="dropdown-header">Project</li>
                         <li><a href="/about_jena/about.html">About Jena</a></li>
-                        <li><a href="/about_jena/citing.html">Citing</a></li>
-                        <li><a href="/about_jena/roadmap.html">Roadmap</a></li>
                         <li><a href="/about_jena/architecture.html">Architecture</a></li>
+                        <li><a href="/about_jena/citing.html">Citing</a></li>
                         <li><a href="/about_jena/team.html">Project team</a></li>
                         <li><a href="/about_jena/contributions.html">Related projects</a></li>
+                        <li><a href="/about_jena/roadmap.html">Roadmap</a></li>
                         <li class="divider"></li>
                         <li class="dropdown-header">ASF</li>
                         <li><a href="http://www.apache.org/">Apache Software Foundation</a></li>
-                        <li><a href="http://www.apache.org/licenses/LICENSE-2.0">License</a></li>
-                        <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
                         <li><a href="http://www.apache.org/foundation/sponsorship.html">Become a Sponsor</a></li>
+                        <li><a href="http://www.apache.org/licenses/LICENSE-2.0">License</a></li>
                         <li><a href="http://www.apache.org/security/">Security</a></li>
+                        <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
                     </ul>
                 </li>
 {{/* Fixup for Hugo warning : was .Page.Path */ -}}


### PR DESCRIPTION
@afs probably my OCD, but it has always bothered me when I had to search things in the docs, and the items in the menu didn't follow an order (or my brain didn't recognize one.)

What about sorting the entries in more-or-less an alphabetical order? The “Learn” menu has the "Overview“ items that I would put first as they serve as introduction to each subsection. But for the other items I think we can make an effort to keep them more or less in alphabetical order? Not a big issue if eventually we add an item in the wrong order, as it can be fixed later (we can also move them to YAML later, automating the sorting process).

WDYT?

![image](https://user-images.githubusercontent.com/304786/158115835-a84ab1f4-7257-48a9-8b22-652e0a7b3b2a.png)

![image](https://user-images.githubusercontent.com/304786/158115858-0e7920c3-11c1-4e16-b149-14309e33c996.png)

![image](https://user-images.githubusercontent.com/304786/158115894-76148390-ed61-4373-999a-614c0a13c737.png)
