### PR TITLE
Update info on compacting for tdb2 and add stats

### DIFF
--- a/source/documentation/fuseki2/fuseki-server-protocol.md
+++ b/source/documentation/fuseki2/fuseki-server-protocol.md
@@ -43,7 +43,7 @@ Replace `{name}` with a dataset name: e.g. `/$/backup/myDataset`.
 ||
 | <tt>POST</tt>   | `/$/backup/{name}`     |               |
 | <tt>GET</tt>    | `/$/backups-list`      |               |
-| <tt>POST</tt>   | `/$/compact/{name}`    |               |
+| <tt>POST</tt>   | `/$/compact/{name}?deleteOld=true` |               |
 | <tt>POST</tt>   | `/$/sleep`             |               |
 ||
 | <tt>GET</tt>    | `/$/tasks`             |               | 
@@ -171,6 +171,8 @@ a list of file names.
 Pattern: `/$/compact/{name}`
 
 This operations initiates a database compaction task and returns a JSON object with the task Id in it.
+
+The optional parameter and value `deleteOld=true` deletes the database which currently is compacted after compacting completion.
 
 Compaction **ONLY** applies to TDB2 datasets, see [TDB2 Database Administration](../tdb2/tdb2_admin.html#compaction)
 for more details of this operation.

--- a/source/documentation/tdb2/tdb2_admin.md
+++ b/source/documentation/tdb2/tdb2_admin.md
@@ -39,7 +39,11 @@ latest view of the RDF dataset into that directory, then switch to using
 that generation of the database. 
 
 There is also a command line tool `tdb2.tdbcompact` to run the
-compaction process on a database not in use.
+compaction process on a database not in use. The command line
+option  `--deleteOld` removes the last database after compaction.
+
+Compaction can also be called from [the Fuseki HTTP Administration Protocol](/documentation/fuseki2/fuseki-server-protocol.html#compact)
+for live [Fuseki webapps](/documentation/fuseki2/fuseki-webapp.html).
 
 ## Backup
 

--- a/source/documentation/tdb2/tdb2_cmds.md
+++ b/source/documentation/tdb2/tdb2_cmds.md
@@ -14,6 +14,7 @@ These scripts are available jena binary distribution.
 * `tdb2.tdbloader`
 * `tdb2.tdbquery`
 * `tdb2.tdbupdate`
+* `tdb2.tdbstats`
 
 On MS Windows, these commands are called `tdb2_tdbquery` etc.
 
@@ -105,3 +106,10 @@ The parallel loader runs all operations at once. It can deliver the best
 performance providing enough RAM is available and the persistent storage
 is SSD. It can consume all hardware resources, greatly impacting
 any other applications running.
+
+## `tdb2.tdbstats`
+
+Produce statistics for the dataset, which can be used for optimization rules. See the
+[TDB Optimizer description.](../tdb/optimizer.html#statistics-rule-file).
+
+For TDB2 the statistic files is read and placed in the `Data-NNNN` directory (`Data-0001/stats.opt`).

--- a/source/documentation/tools/__index.md
+++ b/source/documentation/tools/__index.md
@@ -119,7 +119,7 @@ pages describe these further.
 
 - **`tdbbackup`**, **`tdb2.tdbbackup`**: create a gzipped copy of the Fuseki dataset's triples.
 
-- **`tdbcompact`**, **`tdb2.tdbcompact`**: reduce the size of the Fuseki dataset.
+- **not implemented for TDB1**, **`tdb2.tdbcompact`**: reduce the size of the Fuseki dataset.
 
 
 


### PR DESCRIPTION
Adding some info from the recent thread on jena-users discussed in [Large *.dat files in Fuseki](https://lists.apache.org/thread/r5xj4v8zsmy75gfrfs7vojhbx6r4kj9t)