### PR TITLE
Fuseki optimizer and logging documentation improvements

### DIFF
--- a/source/documentation/fuseki2/fuseki-logging.md
+++ b/source/documentation/fuseki2/fuseki-logging.md
@@ -12,7 +12,7 @@ the Tomcat configuration if running the WAR file.
 | Full Log name                   | Usage |
 |---------------                  |-------|
 | org.apache.jena.fuseki.Server   | General Server Messages              |
-| org.apache.jena.fuseki.Request  | NCSA request Log.                    |
+| org.apache.jena.fuseki.Request  | NCSA request Log                     |
 | org.apache.jena.fuseki.Fuseki   | The HTTP request log                 |
 | org.apache.jena.fuseki.Admin    | Administration operations            |
 | org.apache.jena.fuseki.Builder  | Dataset and service build operations |
@@ -41,8 +41,8 @@ The Fuseki Main engine looks for the log4j2 configuration as follows:
 * Use a built-in configuration.
 
 The last step is a fallback to catch the case where Fuseki has been repackaged
-into a new WAR file and `org/apache/jena/fuseki/log4j.properties` omitted, or run from
-the base jar.  It is better to include `org/apache/jena/fuseki/log4j.properties`.
+into a new WAR file and `org/apache/jena/fuseki/log4j2.properties` omitted, or run from
+the base jar.  It is better to include `org/apache/jena/fuseki/log4j2.properties`.
 
 The preferred customization is to use a custom `log4j2.properties` file in the
 directory where Fuseki Main is run.
@@ -52,6 +52,16 @@ which defaults to `/etc/fuseki` on Linux.
 
 For the standalone webapp server, `FUSEKI_BASE` defaults to directory `run/`
 within the directory where the server is run.
+
+The property `fuseki.loglogging` can also be set to `true` for additional logging.
+
+## Setting ARQ explain logging
+
+Query explanation can be turned on by setting the symbol `arq:optReorderBGP` in the context
+to "info", "fine" or "all". This can be done in the Assembler file by setting `ja:context` 
+on the server, dataset, or endpoint:
+
+    [] ja:context [ ja:cxtName "arq:logExec" ;  ja:cxtValue "info" ] .
 
 ## Default setting
 

--- a/source/documentation/query/explain.md
+++ b/source/documentation/query/explain.md
@@ -87,3 +87,4 @@ The command tdbquery takes the same --explain argument.
 
 Logging information levels: see the [logging page](logging.html)
 
+To get ARQ query explanation in Fuseki logs see [Fuseki logging](/documentation/fuseki2/fuseki-logging.html)

--- a/source/documentation/query/logging.md
+++ b/source/documentation/query/logging.md
@@ -36,7 +36,7 @@ Logger Names | Name | Constant | Logger | Use
 `org.apache.jena.arq.info` | `ARQ.logInfoName` | `ARQ.getLoggerInfo()` | General information
 `org.apache.jena.arq.exec` | `ARQ.logExecName` | `ARQ.getLoggerExec()` | Execution information
 
-The reading of `log4j.properties` from the current directory is achieved
+The reading of `log4j2.properties` from the current directory is achieved
 by a call to `org.apache.jena.atlas.logging.Log.setlog4j2()`.
 
 Example `log4j2.properties` file:
@@ -63,14 +63,15 @@ logger.jena.level = INFO
 logger.arq-exec.name  = org.apache.jena.arq.exec
 logger.arq-exec.level = INFO
 
-logger.arq-info.name  = org.apache.jena.arq.exec
+logger.arq-info.name  = org.apache.jena.arq.info
 logger.arq-info.level = INFO
 
 logger.riot.name  = org.apache.jena.riot
 logger.riot.level = INFO
 ```
 A [Fuseki](../serving/data/index.html)
-server output can include [ARQ execution logging](explain.html "ARQ/Explain").
+server output can include [ARQ execution logging](explain.html "ARQ/Explain"),
+see [Fuseki logging](/documentation/fuseki2/fuseki-logging.html) for the configuration.
 
 ## Execution Logging
 
@@ -83,7 +84,7 @@ the execution context.
 
 The logger used is called `org.apache.jena.arq.exec`. Message are sent
 at level "info". So for log4j2, the following can be set in the
-log4j2.properties file:
+`log4j2.properties` file:
 
     logger.arq-exec.name  = org.apache.jena.arq.exec
     logger.arq-exec.level = INFO

--- a/source/documentation/tdb/optimizer.md
+++ b/source/documentation/tdb/optimizer.md
@@ -65,18 +65,20 @@ Optimizer control files
 
 | File name   | Effect   |
 | ----------- | -------- |
-| `none.opt`  | No reordering - execute triple patterns in the order in the query |
 |`fixed.opt`  | Use a built-in reordering based on the number of variables in a triple pattern.
 |`stats.opt`  | The contents of this file are the weighing rules (see below).
 
-The contents of the files `none.opt` and `fixed.opt` are not read
-and don't matter. They can be zero-length files.
+The contents of the file `fixed.opt` are not read
+and don't matter, it can be a zero-length file.
 
 If more then one file is found, the choice is made: `stats.opt`
-over `fixed.opt` over `none.opt`.
+over `fixed.opt`.
 
-The "no reorder" strategy can be useful in investigating the
-effects. Filter placement still takes place.
+Optimization can be disabled by setting `arq:optReorderBGP` to false. This can be
+done in the Assembler file by setting `ja:context` on the server, dataset, or endpoint:
+
+    [] ja:context [ ja:cxtName "arq:optReorderBGP" ;  ja:cxtValue false ] .
+
 
 ## Filter placement
 
@@ -98,13 +100,13 @@ setting means it is possible to log some queries and not others.
 
 The logger used is called `org.apache.jena.arq.exec`. Messages are
 sent at level "INFO". So for log4j2, the following can be set in the
-log4j2.properties file:
+`log4j2.properties` file:
 
     # Execution logging
     logger.arq-exec.name  = org.apache.jena.arq.exec
     logger.arq-exec.level = INFO
 
-    logger.arq-info.name  = org.apache.jena.arq.exec
+    logger.arq-info.name  = org.apache.jena.arq.info
     logger.arq-info.level = INFO
 
 The context setting is for key (Java constant) `ARQ.symLogExec`. To
@@ -125,6 +127,11 @@ local context.
 On the command line:
 
      tdbquery --set arq:logExec=true --file queryfile
+
+This can also be done in the Assembler file by setting `ja:context` 
+on the server, dataset, or endpoint:
+
+    [] ja:context [ ja:cxtName "arq:logExec" ;  ja:cxtValue "info" ] .
 
 ## Explanation Levels
 

--- a/source/documentation/tdb/optimizer.md
+++ b/source/documentation/tdb/optimizer.md
@@ -65,14 +65,15 @@ Optimizer control files
 
 | File name   | Effect   |
 | ----------- | -------- |
+| `none.opt`  | No reordering - execute triple patterns in the order in the query |
 |`fixed.opt`  | Use a built-in reordering based on the number of variables in a triple pattern.
 |`stats.opt`  | The contents of this file are the weighing rules (see below).
 
-The contents of the file `fixed.opt` are not read
-and don't matter, it can be a zero-length file.
+The contents of the files `none.opt` and `fixed.opt` are not read
+and don't matter. They can be zero-length files.
 
 If more then one file is found, the choice is made: `stats.opt`
-over `fixed.opt`.
+over `fixed.opt` over `none.opt`.
 
 Optimization can be disabled by setting `arq:optReorderBGP` to false. This can be
 done in the Assembler file by setting `ja:context` on the server, dataset, or endpoint:


### PR DESCRIPTION
- document use of context keys `arq:logExec` and `arq:optReorderBGP`
- changing some `lg4j.properties` to `log4j2.properties`