### PR TITLE
change ShexMap to ShapeMap

### DIFF
--- a/source/documentation/shex/__index.md
+++ b/source/documentation/shex/__index.md
@@ -30,8 +30,8 @@ argument.
 
 To validate:
 
-<pre>shex validate --schema SCHEMA.shex --map MAP.shexmap --data DATA.ttl</pre>
-<pre>shex v -s SCHEMA.shex -m MAp.shexmap -d data.ttl</pre>
+<pre>shex validate --schema SCHEMA.shex --map MAP.smap --data DATA.ttl</pre>
+<pre>shex v -s SCHEMA.shex -m MAP.smap -d data.ttl</pre>
 
 To parse a file:
 
@@ -73,7 +73,7 @@ https://github.com/apache/jena/tree/main/jena-examples/src/main/java/shex/exampl
 
         // Shapes map.
         System.out.println("Read shapes map");
-        ShexMap shapeMap = Shex.readShapeMap(SHAPES_MAP);
+        ShapeMap shapeMap = Shex.readShapeMap(SHAPES_MAP);
 
         // ShexReport
         System.out.println("Validate");


### PR DESCRIPTION
Change `ShexMap` type in documentation examples to `ShapeMap`
`.shexmap` files are renamed to `.smap` in accordance with emerging convention.

Accompanies apache/jena#1589
