### PR TITLE
Add a Security Advisories page to the website

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -126,6 +126,7 @@
                         <li><a href="/about_jena/team.html">Project team</a></li>
                         <li><a href="/about_jena/contributions.html">Related projects</a></li>
                         <li><a href="/about_jena/roadmap.html">Roadmap</a></li>
+                        <li><a href="/about_jena/security-advisories.html">Security Advisories</a></li>
                         <li class="divider"></li>
                         <li class="dropdown-header">ASF</li>
                         <li><a href="http://www.apache.org/">Apache Software Foundation</a></li>

--- a/source/about_jena/contributions.md
+++ b/source/about_jena/contributions.md
@@ -11,7 +11,7 @@ This list is provided for information purposes only, and is not meant as an
 endorsement of the mentioned projects by the Jena team.
 
 If you wish your contribution to appear on this page, please raise a
-Jira or GitHub issue with the details to be published.
+ GitHub or JIRA issue with the details to be published.
 
 ## Related projects
 

--- a/source/about_jena/contributions.md
+++ b/source/about_jena/contributions.md
@@ -11,7 +11,7 @@ This list is provided for information purposes only, and is not meant as an
 endorsement of the mentioned projects by the Jena team.
 
 If you wish your contribution to appear on this page, please raise a
-Jira issue with the details to be published.
+Jira or GitHub issue with the details to be published.
 
 ## Related projects
 

--- a/source/about_jena/security-advisories.md
+++ b/source/about_jena/security-advisories.md
@@ -1,0 +1,103 @@
+---
+title: Jena Security Advisories
+---
+
+# Security Issue Policy
+
+## Process
+
+Jena follows the standard [ASF Security for Committers](https://www.apache.org/security/committers.html) policy for
+reporting and addressing security issues.
+
+If you think you have identified a Security issue in our project please refer to that policy for how to report it, and
+the process that the Jena Project Management Committe (PMC) will follow in addressing the issue.
+
+## Single Supported Version
+
+As a project with a relatively small developer community Apache Jena only has the resources to maintain a single release
+version.  Therefore any accepted security issue reported will be fixed by developing a fix for our `main` branch.  We
+will then make a release with the fix in a timeframe appropriate to the severity of the issue.  
+
+## Standard Mitigation Advice
+
+Note that as a project our guidance to users is **always** to use the newest Jena version available to ensure you have
+any security fixes we have made available.
+
+Where more specific mitigations are available these will be denoted in the individual CVEs.
+
+## End of Life (EOL) Components
+
+Where a security advisory is issued for a component that is already EOL (sometimes referred to as archived or retired
+within our documentation) then we will not fix the issue but instead reiterate our previous recommendations that users
+cease using the EOL component and migrate to actively supported components.
+
+Such issues will follow the [CVE EOL Assignment
+Process](https://cve.mitre.org/cve/cna/CVE_Program_End_of_Life_EOL_Assignment_Process.html) and will be clearly denoted
+by the **UNSUPPORTED WHEN ASSIGNED** text at the start of the description.
+
+## Security Issues in Dependencies
+
+For our dependencies the project relies primarily upon GitHub Dependabot Alerts to be made aware of available dependency
+updates, whether security related or otherwise.  When a security related update is released and our analysis shows that
+Jena users may be affected we endeavour to take the dependency upgrade ASAP and make a new release in timeframe
+appropriate to the severity of the issue.
+
+# Jena CVEs
+
+The following CVEs specifically relate to the Jena codebase itself and have been addressed by the project. Per our
+policy above we advise users to always utilise the latest Jena release available.
+
+Please refer to the individual CVE links for further details and mitigations.
+
+## CVE-2022-45136 - JDBC Serialisation in Apache Jena SDB
+
+[CVE-2022-45136](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-45136) affects all versions of [Jena
+SDB](../documentation/archive/sdb/) up to and including the final 3.17.0 release
+
+Apache Jena SDB has been EOL since December 2020 and we recommend any remaining users migrate to [Jena TDB
+2](../documentation/tdb2/) or other 3rd party vendor alternatives.
+
+Apache Jena would like to thank Crilwa & LaNyer640 for reporting this issue
+
+## CVE-2022-28890 - Processing External DTDs
+
+[CVE-2022-28890](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-28890) affects the RDF/XML parser in Jena 4.4.0
+only
+
+Users should upgrade to latest Jena 4.x [release](../download/) available.
+
+Apache Jena would like to thank Feras Daragma, Avishag Shapira & Amit Laish (GE Digital, Cyber Security Lab) for their
+report.
+
+## CVE-2021-39239 - XML External Entity (XXE) Vulnerability
+
+[CVE-2021-39239](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-39239) affects XML parsing up to Jena 4.1.0
+
+Users should upgrade to latest Jena 4.x [release](../download/) available.
+
+## CVE-2021-33192 - Display information UI XSS in Apache Jena Fuseki
+
+[CVE-2021-33192](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-33192) affected
+[Fuseki](../documentation/fuseki2/) 2.0.0 through 4.0.0
+
+Users should upgrade to latest Jena 4.x [release](../download/) available.
+
+# CVEs in Jena Dependencies
+
+The following advisories are CVE's in Jena's dependencies that may affect users of Jena, as with Jena specific CVEs our
+standard [Security Issue Policy](#security-issue-policy) applies and any necessary dependency updates, dependency API
+and/or configuration changes have been adopted and released as soon as appropriate.
+
+## log4shell
+
+[CVE-2021-45105](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-45046),
+[CVE-2021-45105](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-45105) and
+[CVE-2021-44832](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-44832), collectively known as
+[log4shell](https://en.wikipedia.org/wiki/Log4Shell) were several vulnerabilities identified in the [Apache
+Log4j](https://logging.apache.org/log4j/2.x/index.html) project that Jena uses as the concrete logging implementation
+for [Fuseki](../documentation/fuseki2/) and our command line tools.
+
+Jena versions prior to 4.4.0 included vulnerable versions of Log4j.
+
+Users should upgrade to latest Jena 4.x [release](../download/) available.
+

--- a/source/about_jena/security-advisories.md
+++ b/source/about_jena/security-advisories.md
@@ -10,7 +10,7 @@ Jena follows the standard [ASF Security for Committers](https://www.apache.org/s
 reporting and addressing security issues.
 
 If you think you have identified a Security issue in our project please refer to that policy for how to report it, and
-the process that the Jena Project Management Committe (PMC) will follow in addressing the issue.
+the process that the Jena Project Management Committee (PMC) will follow in addressing the issue.
 
 ## Single Supported Version
 
@@ -84,7 +84,7 @@ Users should upgrade to latest Jena 4.x [release](../download/) available.
 
 # CVEs in Jena Dependencies
 
-The following advisories are CVE's in Jena's dependencies that may affect users of Jena, as with Jena specific CVEs our
+The following advisories are CVEs in Jena's dependencies that may affect users of Jena, as with Jena specific CVEs our
 standard [Security Issue Policy](#security-issue-policy) applies and any necessary dependency updates, dependency API
 and/or configuration changes have been adopted and released as soon as appropriate.
 

--- a/source/about_jena/security-advisories.md
+++ b/source/about_jena/security-advisories.md
@@ -2,7 +2,9 @@
 title: Jena Security Advisories
 ---
 
-# Security Issue Policy
+The Jena project has issued a number of security advisories during the lifetime of the project.  On this page you'll
+find details of our [security issue process](#process), as well as a listing of our past [CVEs](#jena-cves) as well as relevant [Dependency CVEs](#cves-in-jena-dependencies).
+
 
 ## Process
 
@@ -51,7 +53,7 @@ Please refer to the individual CVE links for further details and mitigations.
 ## CVE-2022-45136 - JDBC Serialisation in Apache Jena SDB
 
 [CVE-2022-45136](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-45136) affects all versions of [Jena
-SDB](../documentation/archive/sdb/) up to and including the final 3.17.0 release
+SDB](../documentation/archive/sdb/) up to and including the final `3.17.0` release.
 
 Apache Jena SDB has been EOL since December 2020 and we recommend any remaining users migrate to [Jena TDB
 2](../documentation/tdb2/) or other 3rd party vendor alternatives.
@@ -61,7 +63,7 @@ Apache Jena would like to thank Crilwa & LaNyer640 for reporting this issue
 ## CVE-2022-28890 - Processing External DTDs
 
 [CVE-2022-28890](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-28890) affects the RDF/XML parser in Jena 4.4.0
-only
+only.
 
 Users should upgrade to latest Jena 4.x [release](../download/) available.
 
@@ -70,14 +72,14 @@ report.
 
 ## CVE-2021-39239 - XML External Entity (XXE) Vulnerability
 
-[CVE-2021-39239](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-39239) affects XML parsing up to Jena 4.1.0
+[CVE-2021-39239](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-39239) affects XML parsing up to and including the Jena `4.1.0` release.
 
 Users should upgrade to latest Jena 4.x [release](../download/) available.
 
 ## CVE-2021-33192 - Display information UI XSS in Apache Jena Fuseki
 
 [CVE-2021-33192](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-33192) affected
-[Fuseki](../documentation/fuseki2/) 2.0.0 through 4.0.0
+[Fuseki](../documentation/fuseki2/) versions `2.0.0` through `4.0.0`.
 
 Users should upgrade to latest Jena 4.x [release](../download/) available.
 
@@ -96,7 +98,7 @@ and/or configuration changes have been adopted and released as soon as appropria
 Log4j](https://logging.apache.org/log4j/2.x/index.html) project that Jena uses as the concrete logging implementation
 for [Fuseki](../documentation/fuseki2/) and our command line tools.
 
-Jena versions prior to 4.4.0 included vulnerable versions of Log4j.
+Jena versions prior to `4.4.0` included vulnerable versions of Log4j.
 
 Users should upgrade to latest Jena 4.x [release](../download/) available.
 

--- a/source/about_jena/security-advisories.md
+++ b/source/about_jena/security-advisories.md
@@ -14,9 +14,8 @@ the process that the Jena Project Management Committee (PMC) will follow in addr
 
 ## Single Supported Version
 
-As a project with a relatively small developer community Apache Jena only has the resources to maintain a single release
-version.  Therefore any accepted security issue reported will be fixed by developing a fix for our `main` branch.  We
-will then make a release with the fix in a timeframe appropriate to the severity of the issue.  
+As a project, Apache Jena only has the resources to maintain a single release
+version.  Any accepted security issue will be fixed in a future release in a timeframe appropriate to the severity of the issue.  
 
 ## Standard Mitigation Advice
 

--- a/source/help_and_support/bugs_and_suggestions.md
+++ b/source/help_and_support/bugs_and_suggestions.md
@@ -2,10 +2,14 @@
 title: Reporting bugs and making suggestions
 ---
 
-Please report bugs using ASF's [JIRA instance for
-Jena](https://issues.apache.org/jira/browse/JENA).  General suggestions or
-requests for changes can also be discussed on the [user list](index.html),
-but are less likely to be accidentally forgotten if you log them into JIRA.
+Please report bugs using [Jena's GitHub Issues](https://github.com/apache/jena/issues) or 
+ASF's [JIRA instance for Jena](https://issues.apache.org/jira/browse/JENA).  
+General suggestions or requests for changes can also be discussed on the [user list](index.html)
+or [Jena's GitHub Discussions](https://github.com/apache/jena/discussions)
+but are less likely to be accidentally forgotten if you log them into JIRA or a GitHub Issue.
+
+For any security issues please refer to our [Security Advisories](../about_jena/security-advisories.md)
+page for how those should be reported and handled.
 
 Patches and other code contributions should also be attached to issues in
 JIRA (click on `More Actions > Attach Files`) or made via git pull requests.


### PR DESCRIPTION
Adds a new Security Advisories page that lists the CVEs we have issued as well as any significant CVEs in our dependencies that users should be aware of.

Also makes an attempt to describe our policy around handling of security issues