### PR TITLE
Create an automatic Table of Contents, position it as a sidebar (large screen) or at the top of page (smaller than large screen)

### DIFF
--- a/assets/sass/jena.scss
+++ b/assets/sass/jena.scss
@@ -1,3 +1,8 @@
+/** Colors **/
+:root {
+  --color-border: #c9c9c9;
+}
+
 /* Tables */
 table td {
   vertical-align: top;
@@ -56,4 +61,34 @@ a {
 
 #jumbotron a span {
   margin-right: 0.3rem;
+}
+
+/* single */
+
+main {
+  article {
+    width: 100%;
+    /* To prevent long lines of code pushing content over the edge of the visible viewport. */
+    pre {
+      white-space: break-spaces;
+    }
+    /* Ditto the above, but for images. */
+    img {
+      max-width: 100%;
+    }
+  }
+  aside.d-xl-flex {
+    width: 17rem;
+    border-left: 1px solid var(--color-border);
+    h2 {
+      padding: 0 0 0 1rem;
+    }
+    nav {
+      ul {
+        list-style: none;
+        padding: 0 0 0 1rem;
+        margin: 0;
+      }
+    }
+  }
 }

--- a/config.toml
+++ b/config.toml
@@ -22,6 +22,12 @@ pygmentsStyle = "emacs"
 # Enable Git variables like commit, lastmod
 enableGitInfo = true
 
+[markup]
+  [markup.tableOfContents]
+    startLevel = 2
+    endLevel = 4
+    ordered = false
+
 [markup.goldmark.renderer]
 unsafe= true
 

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -24,7 +24,9 @@
 
     <link href="/css/bootstrap.min.css" rel="stylesheet" media="screen">
     <link href="/css/bootstrap-icons.css" rel="stylesheet" media="screen">
-    <link href="/css/jena.css" rel="stylesheet" type="text/css">
+    {{- $sass := resources.Get "/sass/jena.scss" -}}
+    {{- $style := $sass | resources.ToCSS | resources.Fingerprint -}}
+    <link rel="stylesheet" type="text/css" href="{{ $style.Permalink }}" integrity="{{ $style.Data.Integrity }}">
     <link rel="shortcut icon" href="/images/favicon.ico" />
     <!-- Uncomment to enable code coloring <link href="/css/codehilite.css" rel="stylesheet" type="text/css"> -->
 </head>

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -1,3 +1,15 @@
 {{ define "main" }}
-	{{ .Content }}
+<main class="d-flex flex-xl-row flex-column">
+  <aside class="text-muted align-self-start mb-3 px-2 d-xl-none d-block">
+    <h2 class="h6 my-2">On this page</h2>
+    {{ .TableOfContents }}
+  </aside>
+  <article class="flex-column me-lg-4">
+    {{ .Content }}
+  </article>
+  <aside class="text-muted align-self-start mb-3 mb-xl-5 px-2 d-none d-xl-flex flex-column sticky-top">
+    <h2 class="h6 my-2">On this page</h2>
+    {{ .TableOfContents }}
+  </aside>
+</main>
 {{ end }}

--- a/source/_index.md
+++ b/source/_index.md
@@ -2,6 +2,7 @@
 title: Home
 ---
 
+<main class="d-flex flex-column">
 <div class="px-5 my-4 bg-light rounded-3" id="jumbotron">
   <div class="container-fluid py-5">
   <h1 class="display-5 fw-bold"><img alt="Apache Jena" src="/images/jena-logo/jena-logo-jumbotron.png"/> Apache Jena</h1>
@@ -62,3 +63,4 @@ title: Home
     </div>
   </div>
 </div>
+</main>

--- a/source/documentation/archive/sdb/commands.md
+++ b/source/documentation/archive/sdb/commands.md
@@ -10,24 +10,6 @@ title: SDB/Commands
 This page describes the command line programs that can be used to
 create an SDB store, load data into it and to issue queries.
 
-## Contents
-
--   [Scripts](#scripts)
-    -   [Script set up](#script-set-up)
-    -   [Argument Structure](#argument-structure)
-
--   [Store Description](#store-description)
-    -   [Modifying the Store Description](#modifying-the-store-description)
-    -   [Logging and Monitoring](#logging-and-monitoring)
-
--   [SDB Commands](#sdb-commands)
-    -   [Database creation](#database-creation)
-    -   [Loading data](#loading-data)
-    -   [Query](#query)
-    -   [Testing](#testing)
-    -   [Other](#other)
-
-
 ## Scripts
 
 The directory `bin/` contains shell scripts to run the commands

--- a/source/documentation/archive/sdb/configuration.md
+++ b/source/documentation/archive/sdb/configuration.md
@@ -12,15 +12,6 @@ options for query processing, not for the database layout and
 storage, which is controlled by
 [store descriptions](store_description.html "SDB/Store Description").
 
-## Contents
-
--   [Setting Options](#setting-options)
--   [Current Options](#current-options)
-    -   [Queries over all Named Graphs](#queries-over-all-named-graphs)
-    -   [Streaming over JDBC](#streaming-over-jdbc)
-    -   [Annotated SQL](#annotated-sql)
-
-
 ## Setting Options
 
 Options can be set globally, throughout the JVM, or on a per query

--- a/source/documentation/archive/sdb/javaapi.md
+++ b/source/documentation/archive/sdb/javaapi.md
@@ -11,19 +11,6 @@ This page describes how to use SDB from Java.
 
 Code examples are in `src-examples/` in the SDB distribution.
 
-## Contents
-
--   [Concepts](#concepts)
--   [Obtaining the Store](#obtaining-the-store)
-    -   [From a configuration file](#from-a-configuration-file)
-    -   [In Java code](#in-java-code)
-    -   [Database User and Password](#database-user-and-password)
--   [Connection Management](#connection-management)
--   [Formatting or Emptying the Store](#formatting-or-emptying-the-store)
--   [Loading data](#loading-data)
--   [Executing Queries](#executing-queries)
--   [Using the Jena Model API with SDB](#using-the-jena-model-api-with-sdb)
-
 ## Concepts
 
 -   `Store`

--- a/source/documentation/archive/sdb/query_performance.md
+++ b/source/documentation/archive/sdb/query_performance.md
@@ -27,13 +27,6 @@ database, and its configuration (particularly amount of memory
 used), as well as the queries themselves all greatly contribute to
 the execution costs.
 
-## Contents
-
--   [Setup](#setup)
--   [LUBM Query 1](#lubm-query-1)
--   [LUBM Query 2](#lubm-query-2)
--   [Summary](#summary)
-
 ## Setup
 
 [Database and hardware setup](loading_performance.html#the-databases-and-hardware "SDB/Loading performance")

--- a/source/documentation/archive/sdb/store_description.md
+++ b/source/documentation/archive/sdb/store_description.md
@@ -21,16 +21,6 @@ Store objects themselves are lightweight so connections to an SDB
 database can be created on a per-request basis as required for use
 in J2EE application servers.
 
-## Contents
-
--   [Store Descriptions](#store-descriptions)
--   [SDB Connections](#sdb-connections)
--   [Example](#example)
--   [Vocabulary](#vocabulary)
-    -   [Store](#store)
-    -   [Connection](#connection)
-
-
 ## Store Descriptions
 
 A store description identifies which storage layout is being used,

--- a/source/documentation/archive/serving_data/fuseki1.md
+++ b/source/documentation/archive/serving_data/fuseki1.md
@@ -20,19 +20,6 @@ The relevant SPARQL standards are:
 -   [SPARQL 1.1 Protocol](http://www.w3.org/TR/sparql11-protocol/)
 -   [SPARQL 1.1 Graph Store HTTP Protocol](http://www.w3.org/TR/sparql11-http-rdf-update/)
 
-## Contents
-
--   [Download](#download-fuseki1)
--   [Getting Started](#getting-started-with-fuseki)
--   [Security](#security-and-access-control)
--   [Logging](#logging)
--   [Server URI scheme](#server-uri-scheme)
--   [Running a Fuseki Server](#running-a-fuseki-server)
--   [Fuseki Configuration File](#fuseki-configuration-file)
--   [SPARQL Over HTTP](#sparql-over-http)
--   [Use from Java](#use-from-java)
--   [Development System](#development-system)
-
 ## Download Fuseki1
 
 Binaries for Fuseki1 are available from the 

--- a/source/documentation/extras/querybuilder/__index.md
+++ b/source/documentation/extras/querybuilder/__index.md
@@ -3,12 +3,7 @@ title: Jena Query Builder - A query builder for Jena.
 slug: index
 ---
 
-
-# Table of Contents
-
-{% toc %}
-
-# Overview
+## Overview
 
 Query Builder provides implementations of Ask, Construct, Select and Update builders that allow developers to create queries without resorting to StringBuilders or similar solutions.  The Query Builder module is an extra package and is found in the `jena-querybuilder` jar. 
 
@@ -28,7 +23,7 @@ produces
     WHERE
       { ?s ?p ?o }
 
-# Constructing Expressions
+## Constructing Expressions
 
 Expressions are primarily used in `filter` and `bind` statements as well as in select clauses.  All the standard expressions are implemented in the `ExprFactory` class.  An `ExprFactory` can be retrieved from any Builder by calling the `getExprFactory()` method.  This will create a Factory that has the same prefix mappings and the query.  An alternative is to construct the `ExprFactory` directly, this factory will not have the prefixes defined in `PrefixMapping.Extended`.
 
@@ -41,7 +36,7 @@ Expressions are primarily used in `filter` and `bind` statements as well as in s
         .addWhere( ?s, "cf:air_temperature", ?v )
 
 
-# Update Builder
+## Update Builder
 
 The `UpdateBuilder` is used to create `Update`, `UpdateDeleteWhere` or `UpdateRequest` objects.  When an `UpdateRequest` is built is contains a single `Update` object as defined by the `UpdateBuilder`.  `Update` objects can  be added to an UpdateRequest using the `appendTo()` method.
 
@@ -60,7 +55,7 @@ The `UpdateBuilder` is used to create `Update`, `UpdateDeleteWhere` or `UpdateRe
         .where( subj, dc:creator, "me")
         .appendTo( req );
 
-# Where Builder
+## Where Builder
 
 In some use cases it is desirable to create a where clause without constructing an entire query.  The `WhereBuilder` is designed to fit this need.  For example to construct the query:
 
@@ -116,7 +111,7 @@ The where clauses could be built inline as:
 
 
 
-# Template Usage
+## Template Usage
 
 In addition to making it easier to build valid queries the QueryBuilder has a clone method.
 Using this a developer can create as "Template" query and add to it as necessary.
@@ -138,7 +133,7 @@ produces
         ?s <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> foaf:person .
       }
 
-# Prepared Statement Usage
+## Prepared Statement Usage
 
 The query builders have the ability to replace variables with other values.  This can be
 

--- a/source/documentation/fuseki2/fuseki-data-access-control.md
+++ b/source/documentation/fuseki2/fuseki-data-access-control.md
@@ -21,21 +21,6 @@ for configuring security over the whole of the Fuseki UI.
 
 This page applies to Fuseki Main.
 
-## Contents
-
-- [HTTPS](#https)
-- [Authentication](#authentication)
-    - [Using curl](#using-curl)
-    - [Using wget](#using-wget)
-- [Access control lists](#acl)
-    - [Format of ja:allowedUsers](#alloweduser)
-    - [Server Level ACLs](#server-acl)
-    - [Dataset Level ACLs](#dataset-acl)
-    - [Endpoint Level ACLs](#endpoint-acl)
-- [Graph Access Control Lists](#graph-acl)
-    - [Graph Security Registry](#graph-security-registry)
-- [Configuring Jetty directly](#jetty-configuration)
-
 ## HTTPS
 
 HTTPS support is configured from the fuseki server command line.

--- a/source/documentation/fuseki2/soh.md
+++ b/source/documentation/fuseki2/soh.md
@@ -21,14 +21,6 @@ Commands:
 Each command supports the `-v` flag to print out details of the
 HTTP interaction.
 
-## Contents
-
--   [SOH SPARQL Query](#soh-sparql-query)
--   [SOH SPARQL HTTP](#soh-sparql-http)
--   [SOH SPARQL Update](#soh-sparql-update)
--   [Service endpoints](#service-endpoints)
-
-
 ## SOH SPARQL Query
 
     s-query --service=endpointURL 'query string'

--- a/source/documentation/inference/__index.md
+++ b/source/documentation/inference/__index.md
@@ -17,18 +17,6 @@ slug: index
   <a href="/help_and_support/index.html">mailing lists</a>
   is welcomed. </p>
 
-## Index {#index}
-<ol>
-  <li><a href="#overview">Overview of inference support</a> </li>
-  <li><a href="#api">The inference API</a></li>
-  <li><a href="#rdfs">The RDFS reasoner</a></li>
-  <li><a href="#owl">The OWL reasoner</a></li>
-  <li><a href="#transitive">The transitive reasoner</a></li>
-  <li><a href="#rules">The general purpose rule engine</a></li>
-  <li><a href="#extensions">Extending the inference support</a></li>
-  <li><a href="#futures">Futures</a></li>
-</ol>
-
 ## Overview of inference support {#overview}
 <p>The Jena inference subsystem is designed to allow a range of inference engines
   or reasoners to be plugged into Jena. Such engines are used to derive additional

--- a/source/documentation/io/arp_sax.md
+++ b/source/documentation/io/arp_sax.md
@@ -9,17 +9,6 @@ these cases, ARP and Jena can be used as a SAX event handler,
 turning SAX events into triples, or a DOM tree can be parsed into a
 Jena Model.
 
-## Contents
-
--   [Overview](#overview)
--   [Sample Code](#sample-code)
--   [Initializing SAX event source](#initializing-sax-event-source)
--   [Error Handler](#error-handler)
--   [Options](#options)
--   [XML Lang and Namespaces](#xml-lang-and-namespaces)
--   [Using your own triple handler](#using-your-own-triple-handler)
--   [Using a DOM as input](#using-a-dom-as-input)
-
 ## 1. Overview
 
 To read an arbitrary SAX source as triples to be added into a Jena

--- a/source/documentation/io/arp_standalone.md
+++ b/source/documentation/io/arp_standalone.md
@@ -6,16 +6,6 @@ ARP can be used both as a Jena subsystem, or as a standalone
 RDF/XML parser. This document gives a quick guide to using ARP
 standalone.
 
-## Contents
-
--   [Overview](#overview)
--   [Sample Code](#sample)
--   [ARP Event Handling](#handlers)
--   [Configuring ARP](#config)
--   [Interrupting ARP](#interrupt)
--   [Using Other SAX Sources](#sax2rdf)
--   [Memory usage](#memory)
-
 ## Overview
 
 To load an RDF file:

--- a/source/documentation/io/rdfxml_howto.md
+++ b/source/documentation/io/rdfxml_howto.md
@@ -7,20 +7,8 @@ The first section gives a quick introduction to the
 I/O subsystem. The other sections are aimed at users wishing to use
 advanced features within the RDF/XML I/O subsystem.
 
-## Contents
+Other content related to Jena RDF/XML How-To includes:
 
-- [Quick Introduction](#quick-introduction)
-- [RDF/XML, RDF/XML-ABBREV](#rdfxml-rdfxml-abbrev)
-- [Character Encoding Issues](#character-encoding-issues)
-  - [Encodings Supported in Jena 2.2 and later](#encodings-supported-in-jena-22-and-later)
-- [When to Use Reader and Writer?](#when-to-use-reader-and-writer)
-- [Introduction to Advanced Jena I/O](#introduction-to-advanced-jena-io)
-- [Advanced RDF/XML Input](#advanced-rdfxml-input)
-  - [ARP properties](#arp-properties)
-  - [Interrupting ARP](#interrupting-arp)
-- [Advanced RDF/XML Output](#advanced-rdfxml-output)
-- [Conformance](#conformance)
-- [Faster RDF/XML I/O](#faster-rdfxml-io)
 - [Details of ARP, the Jena RDF/XML parser](arp.html)
 
 ## Quick Introduction

--- a/source/documentation/notes/sse.md
+++ b/source/documentation/notes/sse.md
@@ -6,35 +6,6 @@ A way to write down data structures in an RDF-centric syntax.
 
 But not an idea for another RDF serialization format.
 
-## Contents
-
--   [Need](#need)
--   [Design Intent](#design-intent)
--   [Other Approaches](#other-approaches)
-    -   [RDF](#rdf)
-    -   [Lisp](#lisp)
-    -   [XML](#xml)
-    -   [JSON](#json)
--   [Design](#design)
-    -   [Tokens](#tokens)
-    -   [SSE Comments](#sse-comments)
-    -   [SSE Escapes](#sse-escapes)
-    -   [Structures](#structures)
--   [Tagged Structures](#tagged-structures)
-    -   [IRI resolution](#iri-resolution)
-        -   [base](#base)
-        -   [prefix](#prefix)
-        -   [Nesting](#nesting)
-    -   [Links](#links)
--   [Building Java Objects](#building-java-objects)
-    -   [SSE Factory](#sse-factory)
--   [Mapping to RDF](#mapping-to-rdf)
--   [SSE Files](#sse-files)
--   [Longer Examples](#longer-examples)
-    -   [Query 1](#query-1)
-    -   [Complete SPARQL Execution](#complete-sparql-execution)
--   [SSE Grammar](#sse-grammar)
-
 ## Need
 
 The [SPARQL algebra](http://www.w3.org/TR/sparql11-query/#sparqlAlgebra)

--- a/source/documentation/query/spatial-query-doc.md
+++ b/source/documentation/query/spatial-query-doc.md
@@ -32,21 +32,6 @@ This query makes a spatial query for the places within 10 kilometres of Bristol 
         ?place rdfs:label ?placeName
     }
 
-## Table of Contents
-
-- [How to Use it by Code](#how-to-use-it-by-code)
-    - [Create Spatial Dataset](#create-spatial-dataset)
-    - [Supported Geo Data for Indexing and Querying](#supported-geo-data-for-indexing-and-querying)
-        - [Builtin Geo Predicates](#builtin-geo-predicates)
-        - [Custom Geo Predicates](#custom-geo-predicates)
-    - [Load Geo Data into Spatial Dataset](#load-geo-data-into-spatial-dataset)
-- [Property Function Library](#property-function-library)
-- [Spatial Dataset Assembler](#spatial-dataset-assembler)
-- [Working with Solr](#working-with-solr)
-- [Working with Fuseki](#working-with-fuseki)
-- [Building a Spatial Index](#building-a-spatial-index)
-
-
 ## How to Use it by Code
 
 ### Create Spatial Dataset

--- a/source/documentation/query/text-query.md
+++ b/source/documentation/query/text-query.md
@@ -74,55 +74,6 @@ distributed across separate machines.
 This [example code](https://github.com/apache/jena/tree/main/jena-text/src/main/java/examples/)
 illustrates creating an in-memory dataset with a Lucene index.
 
-## Table of Contents
-
--   [Architecture](#architecture)
-    -   [One triple equals one document](#one-triple-equals-one-document)
-    -   [One document equals one entity](#one-document-equals-one-entity)
-        -   [External Content](#external-content)
-    -   [External applications](#external-applications)
-    -   [Document structure](#document-structure)
--   [Query with SPARQL](#query-with-sparql)
-    -   [Syntax](#syntax)
-        -   [Input arguments](#input-arguments)
-        -   [Output arguments](#output-arguments)
-    -   [Query strings](#query-strings)
-        -   [Simple queries](#simple-queries)
-        -   [Queries with language tags](#queries-with-language-tags)
-        -   [Queries that retrieve literals](#queries-that-retrieve-literals)
-        -   [Queries with graphs](#queries-with-graphs)
-        -   [Queries across multiple `Fields`](#queries-across-multiple-fields)
-            -   [Multiple fields in the default integration model](#multiple-fields-in-the-default-integration-model)
-            -   [Multiple fields in the one document equals one entity model](#multiple-fields-in-the-one-document-equals-one-entity-model)
-        -   [Queries with _Boolean Operators_ and _Term Modifiers_](#queries-with-boolean-operators-and-term-modifiers)
-        -   [Highlighting](#highlighting)
-    -   [Good practice](#good-practice)
--   [Configuration](#configuration)
-    -   [Text Dataset Assembler](#text-dataset-assembler)
-        -   [Lists of Indexed Properties](#lists-of-indexed-properties)
-    -   [Configuring an analyzer](#configuring-an-analyzer)
-    -   [Configuration by Code](#configuration-by-code)
-    -   [Graph-specific Indexing](#graph-specific-indexing)
-    -   [Linguistic Support with Lucene Index](#linguistic-support-with-lucene-index)
-        - [Explicit Language Field in the Index](#explicit-language-field-in-the-index)
-    	- [SPARQL Linguistic Clause Forms](#sparql-linguistic-clause-forms)
-    	- [LocalizedAnalyzer](#localizedanalyzer)
-    	- [Multilingual Support](#multilingual-support)
-    -   [Generic and Defined Analyzer Support](#generic-and-defined-analyzer-support)
-        - [Generic Analyzers, Tokenizers and Filters](#generic-analyzers-tokenizers-and-filters)
-        - [Defined Analyzers](#defined-analyzers)
-        - [Extending multilingual support](#extending0-multilingual-support)
-        - [Multilingual enhancements for multi-encoding searches](#multilingual-enhancements-for-multi-encoding-searches)
-        - [Naming analyzers for later use](#naming-analyzers-for-later-use)
-    -   [Storing Literal Values](#storing-literal-values)
-- [Working with Fuseki](#working-with-fuseki)
-- [Building a Text Index](#building-a-text-index)
-- [Configuring Alternative TextDocProducers](#configuring-alternative-textdocproducers)
-  - [Default behavior](#default-behavior)
-    - [Example](#example)
-  - [Multiple fields per document](#multiple-fields-per-document)
-- [Maven Dependency](#maven-dependency)
-
 ## Architecture
 
 In general, a text index engine (Lucene or Elasticsearch) indexes
@@ -1846,7 +1797,7 @@ multiple searchable fields by extending `org.apache.jena.sparql.core.DatasetChan
 such as with `org.apache.jena.query.text.TextDocProducerEntities`; however, this form of
 extension is not currently (Jena 3.13.1) functional.
 
-# Maven Dependency
+## Maven Dependency
 
 The <code>jena-text</code> module is included in Fuseki.  To use it within application code,
 then use the following maven dependency:

--- a/source/documentation/tdb/architecture.md
+++ b/source/documentation/tdb/architecture.md
@@ -5,19 +5,6 @@ title: TDB Architecture
 This page gives an overview of the TDB architecture.
 It applies to TDB1 and TDB2 with differences noted.
 
-## Contents
-
--   [Terminology](#terminology)
--   [Design](#design)
-    -   [The Node Table](#the-node-table)
-    -   [Triple and Quad indexes](#triple-and-quad-indexes)
-    -   [Prefixes Table](#prefixes-table)
-    -   [TDB B+Trees](#tdb-btrees)
-    -   [Transactions](#tdb-transactions)
--   [Inline values](#inline-values)
--   [Query Processing](#query-processing)
--   [Caching on 32 and 64 bit Java systems](#caching-on-32-and-64-bit-java-systems)
-
 ## Terminology
 
 Terms like "table" and "index" are used in this description. They

--- a/source/documentation/tdb/assembler.md
+++ b/source/documentation/tdb/assembler.md
@@ -16,14 +16,6 @@ Having the description in a file means that the data that the
 application is going to work on can be changed without changing the
 program code.
 
-## Contents
-
--   [Dataset](#dataset)
-    -   [Union Default Graph](#union-default-graph)
--   [Graph](#graph)
--   [Mixed Datasets](#mixed-datasets)
--   [RDFS](#rdfs)
-
 ## Dataset
 
 This is needed for use in [Fuseki](../fuseki2/ "Fuseki").

--- a/source/documentation/tdb/commands.md
+++ b/source/documentation/tdb/commands.md
@@ -2,23 +2,6 @@
 title: TDB Command-line Utilities
 ---
 
-## Contents
-
--   [Installation](#installation)
--   [Scripts](#scripts)
-    -   [Script set up - bash scripts](#script-set-up-bash-scripts)
-    -   [Script set up - Windows batch files](#script-set-up-windows-batch-files)
--   [Command line script arguments](#command-line-script-arguments)
-    -   [Setting options from the command line](#setting-options-from-the-command-line)
--   [TDB Commands](#tdb-commands)
-    -   [Store description](#store-description)
-    -   [tdbloader](#tdbloader)
-    -   [TDB xloader](#tdb-xloader)
-    -   [tdbquery](#tdbquery)
-    -   [tdbdump](#tdbdump)
-    -   [tdbstats](#tdbstats)
-
-
 ## Installation
 
 From Apache Jena version `2.7.x` onwards, TDB is now installed as part of a single integrated Jena

--- a/source/documentation/tdb/configuration.md
+++ b/source/documentation/tdb/configuration.md
@@ -5,18 +5,6 @@ title: TDB Configuration
 There are a number of configuration options that affect the
 operation of TDB.
 
-## Contents
-
--   [Setting Options](#setting-options)
-    -   [Setting from the command line](#setting-from-the-command-line)
-    -   [Setting with Java System properties](#setting-with-java-system-properties)
--   [Query of the union of named graphs](#query-of-the-union-of-named-graphs)
--   [Logging Query Execution](#logging-query-execution)
--   [Dataset Caching](#dataset-caching)
--   [File Access Mode](#file-access-mode)
--   [TDB Configuration Symbols](#tdb-configuration-symbols)
--   [Advanced Store Configuration](#advanced-store-configuration)
-
 ## Setting Options
 
 Options can be set globally, through out the JVM, or on a per query

--- a/source/documentation/tdb/java_api.md
+++ b/source/documentation/tdb/java_api.md
@@ -8,15 +8,6 @@ Jena API including the
 The application obtains a model or RDF datasets from TDB then uses
 it as for any other model or dataset.
 
-## Contents
-
--   [Constructing a model or dataset](#constructing-a-model-or-dataset)
-    -   [Using a directory name](#using-a-directory-name)
-    -   [Using an assembler file](#using-an-assembler-file)
--   [Bulkloader](#bulkloader)
--   [Concurrency](#concurrency)
--   [Caching and synchronization](#caching-and-synchronization)
-
 TDB also supports [transactions](tdb_transactions.html).
 
 ## Constructing a model or dataset

--- a/source/documentation/tdb/optimizer.md
+++ b/source/documentation/tdb/optimizer.md
@@ -20,26 +20,10 @@ generated. The user can add and modify rules to tune the database
 based on higher level knowledge, such as inverse function
 properties.
 
-## Contents
-
--   [Quickstart](#quickstart)
--   [Running tdbstats](#running-tdbstats)
--   [Choosing the optimizer strategy](#choosing-the-optimizer-strategy)
--   [Filter placement](#filter-placement)
--   [Investigating what is going on](#investigating-what-is-going-on)
--   [Statistics Rule File](#statistics-rule-file)
-    -   [Statistics Rule Language](#statistics-rule-language)
-    -   [Abbreviated Rule Form](#abbreviated-rule-form)
-    -   [Defaults](#defaults)
--   [Generating a statistics file](#generating-a-statistics-file)
-    -   [Generating statistics for Union Graphs](#generating-statistics-for-union-graphs)
--   [Writing Rules](#writing-rules)
-
 The commands look for file `log4j2.properties` in the current directory, as well
 as the usual log4j2 initialization with property `log4j.configurationFile` and
 looking for classpath resource `log4j2.properties`; there is a default setup of
 log4j2 built-in.
-
 
 ## Quickstart
 

--- a/source/documentation/tdb/tdb_transactions.md
+++ b/source/documentation/tdb/tdb_transactions.md
@@ -13,17 +13,6 @@ process termination and system crashes.
 
 Non-transactional use of TDB1 should be avoided; TDB2 only operates with transactions.
 
-## Contents
-
--   [Overview](#overview)
--   [Limitations](#limitations)
--   [API for Transactions](#api-for-transactions)
-    - [Read transactions](#read-transactions)
-    - [Write transactions](#write-transactions)
--   [Multi-threaded use](#multi-threaded-use)
--   [Bulk loading](#bulk-loading)
--   [Multi JVM](#multi-jvm)
-
 ## Overview
 
 TDB2 uses [MVCC](https://en.wikipedia.org/wiki/Multiversion_concurrency_control)

--- a/source/getting_started/__index.md
+++ b/source/getting_started/__index.md
@@ -9,7 +9,7 @@ framework for building [semantic web](https://en.wikipedia.org/wiki/Semantic_Web
 The framework is composed of different APIs interacting together to process RDF data. If you are new here, you might want to
 get started by following one of the [tutorials](/tutorials/index.html). You can also browse [the documentation](/documentation/index.html) if you are interested in a particular topic.
 
-<h2><i class="bi-journal"></i> Tutorials</h2>
+## <i class="bi-journal"></i> Tutorials
 
 * [RDF API tutorial](/tutorials/rdf_api.html) - you will learn 
 the essence of the semantic web and the graph representation
@@ -20,7 +20,7 @@ to formulate expressive queries over RDF data.
 usage of advanced semantic web features such as reasoning over your data using OWL.
 * Finally, [some of the tutorials](/tutorials/index.html) are also available in Traditional Chinese, Portuguese and French.
 
-<h2><i class="bi-book"></i> Documentation</h2>
+## <i class="bi-book"></i> Documentation
 
 The following topics are covered in the documentation:
 
@@ -37,10 +37,10 @@ The following topics are covered in the documentation:
 * [TDB](/documentation/tdb/) - a fast persistent triple store that stores directly to disk
 * [Tools](/documentation/tools/) - various command-line tools and utilities to help developers manage RDF data and other aspects of Jena
 
-<h2><i class="bi-puzzle"></i> Framework Architecture</h2>
+## <i class="bi-puzzle"></i> Framework Architecture
 
 The interaction between the different APIs:
 
 ![Jena architecture overview](/images/jena-architecture.png "Jena architecture overview")
 
-<h2><i class="bi-info-circle"></i> Other resources</h2>
+## <i class="bi-info-circle"></i> Other resources

--- a/source/tutorials/rdf_api.md
+++ b/source/tutorials/rdf_api.md
@@ -2,7 +2,7 @@
 title: An Introduction to RDF and the Jena RDF API
 ---
 
-<h2>Preface</h2>
+## Preface
 
 This is a tutorial introduction to both W3C's Resource Description Framework
 (RDF) and Jena, a Java API for RDF.  It is written for the programmer who is
@@ -29,26 +29,7 @@ model.</p>
 all the examples used in this tutorial can be downloaded from
 <a href="//jena.apache.org/download/index.cgi"><code>jena.apache.org/download/index.cgi</code></a>.</p>
 
-<p></p>
-
-<h2>Table of Contents</h2>
-<ol>
-  <li><a href="#ch-Introduction">Introduction</a></li>
-  <li><a href="#ch-Statements">Statements</a></li>
-  <li><a href="#ch-Writing-RDF">Writing RDF</a></li>
-  <li><a href="#ch-Reading-RDF">Reading RDF</a></li>
-  <li><a href="#ch-Prefixes">Controlling Prefixes</a></li>
-  <li><a href="#ch-Jena-RDF-Packages">Jena RDF Packages</a></li>
-  <li><a href="#ch-Navigating-a-Model">Navigating a Model</a></li>
-  <li><a href="#ch-Querying-a-Model">Querying a Model</a></li>
-  <li><a href="#ch-Operations-on-Models">Operations on Models</a></li>
-  <li><a href="#ch-Containers">Containers</a></li>
-  <li><a href="#ch-More-about-Literals-and-Datatypes">More about Literals and
-    Datatypes</a></li>
-  <li><a href="#ch-Glossary">Glossary</a></li>
-</ol>
-
-<h2><a id="ch-Introduction">Introduction</a></h2>
+## Introduction {# id="ch-Introduction" }
 
 <p>The Resource Description Framework (RDF) is a standard (technically a W3C
 Recommendation) for describing resources. What is a resource?  That is
@@ -193,7 +174,7 @@ Resource johnSmith
 href="https://github.com/apache/jena/tree/main/jena-core/src-examples/jena/examples/rdf/Tutorial02.java">tutorial 2</a> in the /src-examples directory
 of the Jena distribution.</p>
 
-<h2><a id="ch-Statements">Statements</a></h2>
+## Statements {# id="ch-Statements" }
 
 <p>Each arc in an RDF Model is called a <i><a
 href="#glos-Statement">statement</a></i>. Each statement asserts a fact
@@ -283,7 +264,7 @@ href="https://www.w3.org/TR/rdf-testcases/#ntriples">N-Triples</a>.  The name
 means "triple notation".  We will see in the next section that Jena has an
 N-Triples writer built in.</p>
 
-<h2><a id="ch-Writing-RDF">Writing RDF</a></h2>
+## Writing RDF {# id="ch-Writing-RDF" }
 
 <p>Jena has methods for reading and writing RDF as XML. These can be
 used to save an RDF model to a file and later read it back in again.</p>
@@ -377,7 +358,7 @@ RDFDataMgr.write(System.out, model, Lang.NTRIPLES);
 <p>This will produce output similar to that of tutorial 3 which conforms to
 the N-Triples specification.</p>
 
-<h2><a id="ch-Reading-RDF">Reading RDF</a></h2>
+## Reading RDF {# id="ch-Reading-RDF" }
 
 <p><a href="https://github.com/apache/jena/tree/main/jena-core/src-examples/jena/examples/rdf/Tutorial05.java">Tutorial 5</a> demonstrates reading the
 statements recorded in RDF XML form into a model. With this tutorial,
@@ -450,9 +431,9 @@ looks like:</p>
 </rdf:RDF>
 ```
 
-<h2 id="ch-Prefixes">Controlling Prefixes</h2>
+## Controlling Prefixes {# id="ch-Prefixes" }
 
-<h3>Explicit prefix definitions</h3>
+### Explicit prefix definitions
 
 In the previous section, we saw that the output XML declared a namespace
 prefix <code>vcard</code> and used that prefix to abbreviate URIs. While RDF
@@ -600,7 +581,7 @@ adding a whole group of mappings at once; see the documentation for
 <code>PrefixMapping</code> for details.
 
 
-<h2 id="ch-Jena-RDF-Packages">Jena RDF Packages</h2>
+## Jena RDF Packages {# id="ch-Jena-RDF-Packages" }
 
 <p>Jena is a Java API for semantic web applications.  The key RDF package for
 the application developer is
@@ -629,7 +610,7 @@ implementation of <code>Resource</code>, then no conversions between the two
 types will be necessary.</p>
 
 
-<h2 id="ch-Navigating-a-Model">Navigating a Model</h2>
+## Navigating a Model {# id="ch-Navigating-a-Model" }
 
 <p>So far, this tutorial has dealt mainly with creating, reading and writing
 RDF Models. It is now time to deal with accessing information held in a
@@ -749,7 +730,7 @@ The nicknames of "John Smith" are:
 </p>
 
 
-<h2 id="ch-Querying-a-Model">Querying a Model</h2>
+## Querying a Model {# id="ch-Querying-a-Model" }
 
 <p>The previous section dealt with the case of navigating a model from a
 resource with a known URI. This section deals with searching a
@@ -920,7 +901,7 @@ the statements in the Model and test each one individually, whilst the second
 allows indexes maintained by the implementation to improve performance.  Try
 it on a large Model and see for yourself, but make a cup of coffee first.</p>
 
-<h2 id="ch-Operations-on-Models">Operations on Models</h2>
+## Operations on Models {# id="ch-Operations-on-Models" }
 
 <p>Jena provides three operations for manipulating Models as a whole.  These
 are the common set operations of union, intersection and difference.</p>
@@ -987,7 +968,7 @@ and
 Javadocs for more details.
 </p>
 
-<h2 id="ch-Containers">Containers</h2>
+## Containers {# id="ch-Containers" }
 
 <p>RDF defines a special kind of resources for representing collections of
 things. These resources are called <i>containers</i>. The members of a
@@ -1111,7 +1092,7 @@ The RDFCore WG have relaxed this constraint, which allows partial
 representation of containers.  This therefore is an area of Jena may be
 changed in the future.</p>
 
-<h2 id="ch-More-about-Literals-and-Datatypes">More about Literals and Datatypes</h2>
+## More about Literals and Datatypes {# id="ch-More-about-Literals-and-Datatypes" }
 
 <p>RDF literals are not just simple strings.  Literals may have a language
 tag to indicate the language of the literal.  The literal "chat" with an
@@ -1196,7 +1177,7 @@ statement is added.</p>
 Jena supports these using the <i>typed literal</i> mechanisms; they are
 not discussed in this tutorial.</p>
 
-<h2 id="ch-Glossary">Glossary</h2>
+## Glossary {# id="ch-Glossary" }
 
 <dl>
 
@@ -1240,7 +1221,7 @@ Another term for a statement.</dd>
 
 </dl>
 
-<h2>Footnotes</h2>
+## Footnotes
 <ol>
   <li><a id="fn-01"></a>The identifier of an RDF resource can
     include a fragment identifier, e.g.

--- a/source/tutorials/rdf_api_pt.md
+++ b/source/tutorials/rdf_api_pt.md
@@ -2,7 +2,7 @@
 title: Uma Introdução a RDF e à API RDF de Jena
 ---
 
-<h2>Prefácio</h2>
+## Prefácio
 
 Este é um tutorial introdutório ao framework de descrição de recursos (RDF)
 e Jena, uma API Java para RDF. Ele é escrito para programadores que 
@@ -25,23 +25,7 @@ relativamente simples, então esta abordagem não exigirá muito tempo.</p>
 
 <p></p>
 
-<h2>Conteúdo</h2>
-<ol>
-  <li><a href="#ch-Introduction">Introdução</a></li>
-  <li><a href="#ch-Statements">Sentenças</a></li>
-  <li><a href="#ch-Writing-RDF">Escrita de RDF</a></li>
-  <li><a href="#ch-Reading-RDF">Leitura de RDF</a></li>
-  <li><a href="#ch-Prefixes">Controle de Prefixos</a></li>
-  <li><a href="#ch-Jena-RDF-Packages">Pacotes de Jena RDF</a></li>
-  <li><a href="#ch-Navigating-a-Model">Navegação em Modelos</a></li>
-  <li><a href="#ch-Querying-a-Model">Consulta de Modelos</a></li>
-  <li><a href="#ch-Operations-on-Models">Operações em Modelos</a></li>
-  <li><a href="#ch-Containers">Containers</a></li>
-  <li><a href="#ch-More-about-Literals-and-Datatypes">Mais sobre Literais e Datatypes</a></li>
-  <li><a href="#ch-Glossary">Glossário</a></li>
-</ol>
-
-<h2><a id="ch-Introduction">Introdução</a></h2>
+## Introdução {#  id="ch-Introduction" }
 
 <p> O framework de descrição de recursos (RDF) é um padrão (tecnicamente uma recomendação da W3C) para descrever recursos. Mas o que são recursos? Isso é uma questão profunda e a definição precisa ainda é um assunto de debates. Para nossos propósitos, nós podemos pensar em recursos como tudo que podemos identificar. Você é um recurso, assim como sua página pessoal, este tutorial, o número um e a grande baleia branca em Moby Dick.</p>
 
@@ -130,7 +114,7 @@ Resource johnSmith
 
 <p>Os códigos desse exemplo podem ser encontrados no diretório /src-examples no pacote de distribuição do Jena como <a href="https://github.com/apache/jena/tree/main/jena-core/src-examples/jena/examples/rdf/Tutorial02.java">tutorial 2</a>.</p>
 
-<h2><a id="ch-Statements">Sentenças</a></h2>
+## Sentenças {#  id="ch-Statements" }
 
 <p>Cada arco no modelo RDF é chamado de <i><a
 href="#glos-Statement">sentença</a></i>. Cada sentença define um fato sobre o recurso. Uma sentença possui três partes:</p>
@@ -194,7 +178,7 @@ http://somewhere/JohnSmith http://www.w3.org/2001/vcard-rdf/3.0#FN  "John Smith"
 <p>O W3C <a href="https://www.w3.org/2001/sw/RDFCore/">RDFCore Working
 Group</a> definiu uma notação similar chamada <a href="https://www.w3.org/TR/rdf-testcases/#ntriples">N-Triples</a>. O nome significa "notação de triplas". Nós veremos na próxima sessão que o Jena possui uma interface de escrita de N-Triples também.</p>
 
-<h2><a id="ch-Writing-RDF">Escrita de RDF</a></h2>
+## Escrita de RDF {#  id="ch-Writing-RDF" }
 
 <p>Jena possui métodos para ler e escrever RDF como XML. Eles podem ser usados para armazenar o modelo RDF em um arquivo e carregá-lo novamente em outro momento.</p>
 
@@ -252,7 +236,7 @@ RDFDataMgr.write(System.out, model, Lang.NTRIPLES);
 
 <p>Isso produzirá uma saída similar à do tutorial 3, que está em conformidade com a especificação de N-Triplas.</p>
 
-<h2><a id="ch-Reading-RDF">Leitura de RDF</a></h2>
+## Leitura de RDF {#  id="ch-Reading-RDF" }
 
 <p><a href="https://github.com/apache/jena/tree/main/jena-core/src-examples/jena/examples/rdf/Tutorial05.java">Tutorial 5</a> demonstra a leitura  num modelo de sentenças gravadas num RDF XML. Com este tutorial, nós teremos criado uma pequena base de dados de vcards na forma RDF/XML. O código a seguir fará leitura e escrita. <em>Note que para esta aplicação rodar, o arquivo de entrada precisa estar no diretório da aplicação.</em></p>
 
@@ -318,9 +302,9 @@ model.write(System.out);
 &lt;/rdf:RDF&gt;</pre>
 
 
-<h2 id="ch-Prefixes">Controlando prefixos</h2>
+## Controlando prefixos {# id="ch-Prefixes" }
 
-<h3>Definições explícitas de prefixos</h3>
+### Definições explícitas de prefixos
 
 Na sessão anterior, nós vimos que a saída XML declarou um prefixo namespace  
 <code>vcard</code> e o usou para abreviar URIs. Enquanto que RDF usa somente URIs completas, e não sua forma encurtada, Jena provê formas de controlar namespaces usados na saída com seu mapeamento de prefixos. Aqui vai um exemplo simples.
@@ -416,7 +400,7 @@ O outro namespace ainda recebe o nome criado automaticamente, mas o nome nsA é 
 
 Ambos os prefixos são usados na saída, e não houve a necessidade de prefixos gerados automaticamente.
 
-<h3>Definições implícitas de prefixos</h3>
+### Definições implícitas de prefixos
 
 Assim como as declarações de prefixos definidas por chamadas a <code>setNsPrefix</code>, Jena vai lembrar-se dos prefixos que foram usados na entrada para <code>model.read()</code>.
 
@@ -437,7 +421,7 @@ Você verá que os prefixos da entrada são preservados na saída. Todos os pref
 <p>Jena possui outras operações sobre mapeamento de prefixos de um modelo, como um<code>Map</code> de Java extraído a partir dos mapeamentos existentes, ou a adição de um grupo inteiro de mapeamentos de uma só vez; olhe a documentação de <code>PrefixMapping</code> para mais detalhes.
 
 
-<h2 id="ch-Jena-RDF-Packages">Pacotes Jena RDF</h2>
+## Pacotes Jena RDF {# id="ch-Jena-RDF-Packages" }
 
 <p>Jena é uma API JAVA para aplicações de web semântica. O pacote RDF chave para o desenvolvedor é
 <code>org.apache.jena.rdf.model</code>. A API  tem sido definida em termos de interfaces, logo o código da aplicação pode trabalhar com diferentes implementações sem causar mudanças. Esse pacote contém interfaces para representar modelos, recursos, propriedades, literais, sentenças e todos os outros conceitos chaves de RDF, e um ModelFactory para criação de modelos. Portanto, o código da aplicação permanece independente da implementação, o melhor é usar interfaces onde for possível e não implementações específicas de classes.</p>
@@ -448,7 +432,7 @@ Você verá que os prefixos da entrada são preservados na saída. Todos os pref
 <code>PropertyImpl</code>, e <code>LiteralImpl</code> que podem ser usadas diretamente ou então herdadas por diferentes implementações. As aplicações devem raramente usar essas classes diretamente. Por exemplo, em vez de criar um nova instância de  <code>ResourceImpl</code>, é melhor usar o método <code>createResource</code> do modelo que estiver sendo usado. Desta forma, se a implementação do modelo usar uma implementação otimizada de <code>Resource</code>, então não serão necessárias conversões entre os dois tipos.</p>
 
 
-<h2 id="ch-Navigating-a-Model">Navegação em Modelos</h2>
+## Navegação em Modelos {# id="ch-Navigating-a-Model" }
 
 <p>Até agora, este tutorial mostrou como criar, ler e escrever modelos RDF. Chegou o momento de mostrar como acessar as informações mantidas num modelo.</p>
 
@@ -526,7 +510,7 @@ while (iter.hasNext()) {
 </p>
 
 
-<h2 id="ch-Querying-a-Model">Consultas em Modelos</h2>
+## Consultas em Modelos {# id="ch-Querying-a-Model" }
 
 <p>A sessão anterior mostrou como navegar um modelo a partir de um recurso com uma URI conhecida. Essa sessão mostrará como fazer buscas em um modelo. O núcleo da API Jena suporta um limitada primitiva de consulta. As consultas mais poderosas de SPARQL são descritas em outros lugares.</p>
 
@@ -662,7 +646,7 @@ StmtIterator iter = model.listStatements(
 
 <p>Embora possam ser funcionalmente equivalentes, a primeira forma vai listar todas as sentenças do modelo e testar cada uma individualmente, a segunda forma permite índices mantidos pela implementação para melhor a perfomance. Tente isso em modelos grandes e veja você mesmo, mas prepare uma chícara de café antes.</p>
 
-<h2 id="ch-Operations-on-Models">Operações em Modelos</h2>
+## Operações em Modelos {# id="ch-Operations-on-Models" }
 
 <p>Jena provê três operações para manipular modelos. Elas são operações comuns de conjunto: união, intersecção e diferença.</p>
 
@@ -722,7 +706,7 @@ e
 para mais detalhes.
 </p>
 
-<h2 id="ch-Containers">Containers</h2>
+## Containers {# id="ch-Containers" }
 
 <p>RDF defina um tipo especial de recursos para representar coleções de coisas. Esses recursos são chamados de <i>containers</i>. Os membros de um container podem ser tanto literais quanto recursos. Há três tipos de containers:</p>
 <ul>
@@ -813,7 +797,7 @@ tutorial 10</a>, que coloca esses fragmentos de código juntos num exemplo compl
 
 <p>As classes de Jena oferecem métodos para manipular containers, incluindo adição de novos membros, inserção de novos membros no meio de um container e a remoção de membros existentes. As classes de container Jena atualmente garantem que a lista ordenada de propriedades usadas começam com rdf:_1 e é contíguo. O RDFCore WG relaxou essa regra, permitindo uma representação parcial dos containers. Isso, portanto, é uma área de Jena que pode ser mudada no futuro.</p>
 
-<h2 id="ch-More-about-Literals-and-Datatypes">Mais sobre Literais e Datatypes</h2>
+## Mais sobre Literais e Datatypes {# id="ch-More-about-Literals-and-Datatypes" }
 
 <p>Literais RDF não são apenas strings. Literais devem ter uma tag para indicar a linguagem da literal. O diálogo de uma literal em Inglês é considerado diferente de um diálogo de uma literal em Francês. Esse comportamento estranho é um artefato da sintaxe RDF/XML original.</p>
 
@@ -876,7 +860,7 @@ model.write(system.out, "N-TRIPLE");
 
 <p>O RDFCore WG definiu mecanismos para suportar datatypes em RDF. Jena os suporta usando mecanismos de <i>literais tipadas</i>; isso não é discutido neste tutorial.</p>
 
-<h2 id="ch-Glossary">Glossário</h2>
+## Glossário {# id="ch-Glossary" }
 
 <dl>
 


### PR DESCRIPTION
- [x] use Hugo [`TableOfContents`](https://gohugo.io/content-management/toc/)
- [x] use SCSS to use nested styles (instead of multiple `parent {} parent child1 {} parent child2 {}` CSS rules)
- [x] display ToC as a sidebar when viewscreen is extra large (Bootstrap 5, normal laptops/monitors in full screen)
- [x] display ToC as the first element of the post when viewscreen is not extra large (e.g. tablet, mobile)
- [x] maintain the anchor links (i.e. `<h2><a id="ch-anchor1"></h2>`)
- [x] keep the structure of the page
- [x] keep the landing page the same without the ToC

Inspired by the [PyData Sphinx Theme](https://github.com/pydata/pydata-sphinx-theme) used in projects like Pandas, JupyterHub, CWL, etc.

There is no change to the landing page.

Here's what [a page with several headings](https://jena.apache.org/tutorials/rdf_api.html) looks like at https://jena.apache.org at the moment:

![image](https://user-images.githubusercontent.com/304786/216836870-35a87850-200e-497c-8188-3238fd7fa9b7.png)

See that a user with a 14" laptop monitor at 1600x900 (and zoom at ~110/120% plus bigger fonts because bad :eyes: ) doesn't see the table of contents of the page. It can see the beginning of the manually written table of contents, but not see the rest nor navigate without scrolling down the page.

Here's the same page after this pull request:

![image](https://user-images.githubusercontent.com/304786/216836934-dcaec8f7-9ebc-482a-a74d-ee90d9616f96.png)

Same content, and same page, but the table of content is now a) generated automatically from the `<hN>` headings, without breaking existing anchors, and without modifying the contents. The first line ”On this page” was copied from [an example from Bootstrap](https://getbootstrap.com/docs/5.3/examples/cheatsheet/), as I think that's quite intuitive and shorter than "Table of Contents".

The user now can click on any of those links and quickly navigate the page contents. It's also possible to quickly have an idea of what's in the page, and choose to read it or to search for other pages.

Now on mobile:

![image](https://user-images.githubusercontent.com/304786/216837090-83d3eed6-b124-4d35-a72a-16414c16e745.png)

We display the table of contents first, so mobile users can also quickly navigate the page. The cons of this is the extra content at the top of the page, but with an already hidden menu on mobile, hiding the ToC in a burger menu would be confusing. We can drop the ToC completely for smaller screens if others prefer?