### PR TITLE
Minor improvements

### DIFF
--- a/assets/sass/jena.scss
+++ b/assets/sass/jena.scss
@@ -1,8 +1,3 @@
-/** Colors **/
-:root {
-  --color-border: #c9c9c9;
-}
-
 /* Tables */
 table td {
   vertical-align: top;
@@ -79,17 +74,21 @@ main {
   }
   aside.d-xl-flex {
     width: 17rem;
-    border-left: 1px solid var(--color-border);
+    border-left: 1px solid var(--bs-secondary-bg);
     /* The top dropdown menu has the Bootstrap default z-index of 1000.
      * The sticky-top that we use in the aside element gets a z-index of
      * 1020 from Bootstrap, causing the menu to be under this sidebar.
      * This value fixes that.
      */
+    overflow-y: scroll;
+    max-height: 100vh;
     z-index: 999;
     h2 {
-      padding: 0 0 0 1rem;
+      margin-left: 1rem;
+      background-color: var(--bs-body-bg);
     }
     nav {
+      margin-top: 0.5rem;
       ul {
         list-style: none;
         padding: 0 0 0 1rem;

--- a/assets/sass/jena.scss
+++ b/assets/sass/jena.scss
@@ -72,26 +72,45 @@ main {
       max-width: 100%;
     }
   }
-  aside.d-xl-flex {
-    width: 17rem;
-    border-left: 1px solid var(--bs-secondary-bg);
+  aside {
+    &.d-xl-flex {
+      width: 17rem;
+      border-left: 1px solid var(--bs-secondary-bg);
+      overflow-y: scroll;
+      max-height: 100vh;
+      h2 {
+        margin-left: 1rem;
+        background-color: var(--bs-body-bg);
+      }
+      nav {
+        ul {
+          padding: 0 0 0 1rem;
+        }
+      }
+    }
+    &.d-xl-none {
+      nav {
+        ul {
+          padding: 0;
+          li {
+            ul {
+              padding: 0 0 0 1rem;
+            }
+          }
+        }
+      }
+    }
     /* The top dropdown menu has the Bootstrap default z-index of 1000.
      * The sticky-top that we use in the aside element gets a z-index of
      * 1020 from Bootstrap, causing the menu to be under this sidebar.
      * This value fixes that.
      */
-    overflow-y: scroll;
-    max-height: 100vh;
     z-index: 999;
-    h2 {
-      margin-left: 1rem;
-      background-color: var(--bs-body-bg);
-    }
+
     nav {
       margin-top: 0.5rem;
       ul {
         list-style: none;
-        padding: 0 0 0 1rem;
         margin: 0;
       }
     }

--- a/assets/sass/jena.scss
+++ b/assets/sass/jena.scss
@@ -80,6 +80,12 @@ main {
   aside.d-xl-flex {
     width: 17rem;
     border-left: 1px solid var(--color-border);
+    /* The top dropdown menu has the Bootstrap default z-index of 1000.
+     * The sticky-top that we use in the aside element gets a z-index of
+     * 1020 from Bootstrap, causing the menu to be under this sidebar.
+     * This value fixes that.
+     */
+    z-index: 999;
     h2 {
       padding: 0 0 0 1rem;
     }

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -176,15 +176,40 @@
 <script src="/js/improve.js" type="text/javascript"></script>
 <!-- for marking links as active in the navbar-menu -->
 <script type="text/javascript">
-const link = document.querySelector(`a[href="${window.location.pathname}"]`);
-if (link !== undefined && link !== null) {
-    const parents = link.parentElement
-    for (const parent of parents) {
-        if (parent.tagName === 'ul' ||  parent.tagName === 'li') {
-            parent.style += 'active';
+(function() {
+    'use strict'
+    /*
+     * Find the link in the menu that corresponds to the currently open page.
+     * NOTE: We call .querySelectorAll because we may have more than one link
+     *       in the page for the same entry, e.g. the Logo and Home link to
+     *       the same page.
+     */
+    const links = document.querySelectorAll(`a[href="${window.location.pathname}"]`)
+    if (links !== undefined && links !== null) {
+        for (const link of links) {
+            // We may call add twice for this link, but that is fine.
+            link.classList.add('active')
+            let parentElement = link.parentElement
+            let count = 0
+            const levelsLimit = 4
+            // Keep iterating while we have the parent being UL's and LI's, with a hard-limit
+            // (to prevent possibly crashing some tabs with deeply nested and/or long menus).
+            // N.B.: In Bootstrap 5 the navigation menus are composed with UL's, that contain
+            //       LI's, that contain either other UL's (sub-menus) or A's (links). We are
+            //       after the A's.
+            while (['UL', 'LI'].includes(parentElement.tagName) && count <= levelsLimit) {
+                if (parentElement.tagName === 'LI') {
+                    // Here we can rely on the JS API to search the first child A element,
+                    // and if found add the active class. In Bootstrap 5 the link elements
+                    // are marked as active, different than in previous version.
+                    parentElement.querySelector('a:first-child').classList.add('active')
+                }
+                parentElement = parentElement.parentElement
+                count++
+            }
         }
     }
-}
+})()
 </script>
 
 </body>

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -1,12 +1,14 @@
 {{ define "main" }}
 <main class="d-flex flex-xl-row flex-column">
-  <aside class="text-muted align-self-start mb-3 px-2 d-xl-none d-block">
+  <!-- This one is for mobile and small viewport. -->
+  <aside class="text-muted align-self-start mb-3 p-0 d-xl-none d-block">
     <h2 class="h6 my-2">On this page</h2>
     {{ .TableOfContents }}
   </aside>
   <article class="flex-column me-lg-4">
     {{ .Content }}
   </article>
+  <!-- This one is for large viewport. -->
   <aside class="text-muted align-self-start mb-3 mb-xl-5 p-0 d-none d-xl-flex flex-column sticky-top">
     <h2 class="h6 sticky-top m-0 p-2 bg-body-tertiary">On this page</h2>
     {{ .TableOfContents }}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -7,8 +7,8 @@
   <article class="flex-column me-lg-4">
     {{ .Content }}
   </article>
-  <aside class="text-muted align-self-start mb-3 mb-xl-5 px-2 d-none d-xl-flex flex-column sticky-top">
-    <h2 class="h6 my-2">On this page</h2>
+  <aside class="text-muted align-self-start mb-3 mb-xl-5 p-0 d-none d-xl-flex flex-column sticky-top">
+    <h2 class="h6 sticky-top m-0 p-2 bg-body-tertiary">On this page</h2>
     {{ .TableOfContents }}
   </aside>
 </main>


### PR DESCRIPTION
Follow-up for #144 (more to come soon!). Separated commits to allow for dropping/editing changes if needed.

## 1) z-index menu

Bootstrap's z-index for dropdown menus is `1000`, but for the sticky elements is `1020`, so the sticky sidebar is displayed above the dropdown menu. This PR fixes it, screenshots below.

![Screenshot from 2023-02-11 22-46-24](https://user-images.githubusercontent.com/304786/218285714-138e7d53-33b8-4f55-858e-ae376f50539e.png)

![Screenshot from 2023-02-11 22-48-14](https://user-images.githubusercontent.com/304786/218285717-e5207801-a5d8-439f-b781-ab9884453756.png)

## 2) Active menu items

![image](https://user-images.githubusercontent.com/304786/218285732-567868ad-41f3-4874-b0c9-59625dc060eb.png)

As seen in the screenshot, at the moment jena.apache.org has a JS error, and nothing is marked as active. This PR has a commit that re-writes that function with more modern JS, and with code that's compatible with Bootstrap 5, where links are marked as active, instead of dropdown menu entries. Note that for now it's using active colors from Bootstrap, so darker black for top menu, and white text with blue background for dropdown entries.

![Screenshot from 2023-02-12 00-22-33](https://user-images.githubusercontent.com/304786/218285759-6890b2b4-bcdd-49a7-9df4-e392c163e55b.png)

## 3) Scrollable ToC sidebar

I noticed that certain pages, like GeoSPARQL and Jena Text required readers to scroll all the way to the top so that the last entries in the long ToC were accessible. This PR has a commit that adds a scroll to the ToC to fix that.

![Screenshot from 2023-02-12 00-24-11](https://user-images.githubusercontent.com/304786/218285802-49c277ab-0f10-466f-abce-0cb9f826c0aa.png)

## 4) Align ToC for smaller viewports

I had not noticed that the ToC was not well aligned in the smaller viewports, sorry. Fixed as below.

![Screenshot from 2023-02-12 00-32-43](https://user-images.githubusercontent.com/304786/218285838-476e4164-9f0a-494c-af7b-c54c4af984dc.png)
![Screenshot from 2023-02-12 00-32-57](https://user-images.githubusercontent.com/304786/218285840-28b67cd1-b34c-42da-83b2-3bc36d729272.png)

Cheers,
B