### PR TITLE
fix broken geosparql comparison table

### DIFF
--- a/source/documentation/geosparql/__index.md
+++ b/source/documentation/geosparql/__index.md
@@ -622,9 +622,7 @@ implementation based on reviewing several alternatives.
 
 This Implementation|Other Implementations
 ---------- | ----------
-Implements all six components of the GeoSPARQL standard.|Generally partially implement the Geometry Topology and Geometry Extensions. Do not implement the Query Rewrite
-Extension.
-
+Implements all six components of the GeoSPARQL standard.|Generally partially implement the Geometry Topology and Geometry Extensions. Do not implement the Query Rewrite Extension.
 Pure Java and does not require a supporting relational database. Configuration requires a single line of code (although Apache SIS may need some setting up, see above).|Require setting up a database, configuring a geospatial extension and setting environment variables.
 Uses Jena, which conforms to the W3C standards for RDF and SPARQL. New versions of the standards will quickly feed through.|Not fully RDF and SPARQL compliant, e.g. RDFS/OWL inferencing or SPARQL syntax. Adding your own schema may not produce inferences.
 Automatically determines geometry properties and handles mixed cases of units or coordinate reference systems. The GeoSPARQL standard suggests this approach but does not require it.|Tend to produce errors or no results in these situations.


### PR DESCRIPTION
It looks like this table broke during the documentation upgrade.

![broken-table](https://user-images.githubusercontent.com/5328572/230186575-ab8e3b38-bfbe-4f98-8c88-2a8fe7eebede.png)


Haven't confirmed the fix, since I don't have a local setup.

