### PR TITLE
Fix rdf-thrift URL

### DIFF
--- a/source/documentation/io/rdf-binary.md
+++ b/source/documentation/io/rdf-binary.md
@@ -23,7 +23,7 @@ systems.
 widely-used, binary encoding layers each with a large number of language
 bindings.
 
-For more details of [RDF Thrift](http://afs.github.io/rdf-thrift).
+For more details of [RDF Thrift](https://afs.github.io/rdf-thrift/).
 
 ## Thrift encoding of RDF Terms {#encoding-terms-thrift}
 


### PR DESCRIPTION
The previous rdf-thrift URL (https://afs.github.io/rdf-thrift) does not render in Chrome/OSX, assumedly due to a missing redirect.

```
$ curl -IL https://afs.github.io/rdf-thrift
HTTP/2 200
server: GitHub.com
content-type: text/html; charset=utf-8
permissions-policy: interest-cohort=()
last-modified: Sat, 03 Dec 2022 10:51:05 GMT
access-control-allow-origin: *
etag: "638b2a19-3cc"
expires: Thu, 18 Jan 2024 08:17:23 GMT
cache-control: max-age=600
x-proxy-cache: MISS
x-github-request-id: F4C2:2FFA55:585BEB3:59B9FAD:65A8DC3B
accept-ranges: bytes
date: Thu, 18 Jan 2024 08:07:38 GMT
via: 1.1 varnish
age: 15
x-served-by: cache-fra-eddf8230085-FRA
x-cache: HIT
x-cache-hits: 1
x-timer: S1705565258.486688,VS0,VE2
vary: Accept-Encoding
x-fastly-request-id: 44210949b1d61366b2f3687dfebb857648e79ece
content-length: 972

$ curl -IL https://afs.github.io/rdf-thrift/
HTTP/2 200
server: GitHub.com
content-type: text/html; charset=utf-8
permissions-policy: interest-cohort=()
last-modified: Sat, 03 Dec 2022 10:51:05 GMT
access-control-allow-origin: *
etag: "638b2a19-ca9"
expires: Thu, 18 Jan 2024 08:18:34 GMT
cache-control: max-age=600
x-proxy-cache: MISS
x-github-request-id: 0CF2:2C7005:302E610:30EB27B:65A8DC82
accept-ranges: bytes
date: Thu, 18 Jan 2024 08:08:34 GMT
via: 1.1 varnish
age: 0
x-served-by: cache-fra-eddf8230034-FRA
x-cache: MISS
x-cache-hits: 0
x-timer: S1705565314.436379,VS0,VE102
vary: Accept-Encoding
x-fastly-request-id: 26f87c34d577b083f023642c07a2318ae27df25b
content-length: 3241
```