### PR TITLE
Updates for Jena5.

### DIFF
--- a/source/documentation/io/__index.md
+++ b/source/documentation/io/__index.md
@@ -10,7 +10,6 @@ This page details the setup of RDF I/O technology (RIOT).
 * [Reading RDF in Jena](rdf-input.html)
 * [Writing RDF in Jena](rdf-output.html)
 * [Working with RDF Streams](streaming-io.html)
-* [Additional details on working with RDF/XML](rdfxml-io.html)
 
 ## Formats
 
@@ -18,19 +17,17 @@ The following RDF formats are supported by Jena. In addition, other syntaxes
 can be integrated into both the parser and writer registries.
 
 - Turtle
-- RDF/XML
-- N-Triples
 - JSON-LD
-- RDF/JSON
-- TriG
+- N-Triples
 - N-Quads
+- TriG
+- RDF/XML
 - TriX
+- RDF/JSON
 - RDF Binary
 
 RDF/JSON is different from JSON-LD - it is a direct encoding of RDF triples in JSON.
 See the [description of RDF/JSON](rdf-json.html).
-
-From Jena 4.5.0, JSON-LD 1.1 is the main supported version of JSON-LD.
 
 RDF Binary is a binary encoding of RDF (graphs and datasets) that can be useful
 for fast parsing.  See [RDF Binary](rdf-binary.html).
@@ -96,7 +93,6 @@ get command line reminders):
 -   `--output=FORMAT`: Output in a given syntax (streaming if possible).
 -   `--formatted=FORMAT`: Output in a given syntax, using pretty printing.
 -   `--stream=FORMAT`: Output in a given syntax, streaming (not all syntaxes can be streamed).
-
 
 To aid in checking for errors in UTF8-encoded files, there is a
 utility which reads a file of bytes as UTF8 and checks the encoding.

--- a/source/documentation/io/arp/arp.md
+++ b/source/documentation/io/arp/arp.md
@@ -2,6 +2,14 @@
 title: RDF/XML Input in Jena
 ---
 
+___Legacy Documentation : not up-to-date___
+
+___The original ARP parser will be removed from Jena___
+
+The current RDF/XML parser is RRX.
+
+---
+
 This section details the Jena RDF/XML parser.
 ARP is the parsing subsystem in Jena for handling the RDF/XML syntax.
 

--- a/source/documentation/io/arp/arp_sax.md
+++ b/source/documentation/io/arp/arp_sax.md
@@ -2,6 +2,12 @@
 title: SAX Input into Jena and ARP
 ---
 
+___Legacy Documentation : not up-to-date___
+
+___The original ARQ parser will be removed from Jena___
+
+---
+
 Normally, both ARP and Jena are used to read files either from the
 local machine or from the Web. A different use case, addressed
 here, is when the XML source is available in-memory in some way. In

--- a/source/documentation/io/arp/arp_standalone.md
+++ b/source/documentation/io/arp/arp_standalone.md
@@ -2,6 +2,12 @@
 title: Using ARP Without Jena
 ---
 
+__Legacy Documentation : not up-to-date__
+
+__The original ARQ parser will be removed from Jena.__
+
+---
+
 ARP can be used both as a Jena subsystem, or as a standalone
 RDF/XML parser. This document gives a quick guide to using ARP
 standalone.

--- a/source/documentation/io/rdf-input.md
+++ b/source/documentation/io/rdf-input.md
@@ -184,7 +184,7 @@ copies of import http resources).
 Location mapping files are RDF, usually written in Turtle although
 an RDF syntax can be used.
 
-    @prefix lm: <http://jena.hpl.hp.com/2004/08/location-mapping#> .
+    PREFIX lm: <http://jena.hpl.hp.com/2004/08/location-mapping#>
 
     [] lm:mapping
        [ lm:name "file:foo.ttl" ;      lm:altName "file:etc/foo.ttl" ] ,

--- a/source/documentation/io/rdf-output.md
+++ b/source/documentation/io/rdf-output.md
@@ -22,9 +22,6 @@ See [Reading RDF](rdf-input.html) for details of the RIOT Reader system.
 - [Examples](#examples)
 - [Notes](#notes)
 
-See [Advanced RDF/XML Output](rdfxml_howto.html#advanced-rdfxml-output) 
-for details of the Jena RDF/XML writer.
-
 ## API {#api}
 
 There are two ways to write RDF data using Apache Jena RIOT, 
@@ -136,10 +133,10 @@ or write N-triples/N-Quads.
 
 Example:
 
-    @prefix :      <http://example/> .
-    @prefix dc:    <http://purl.org/dc/elements/1.1/> .
-    @prefix foaf:  <http://xmlns.com/foaf/0.1/> .
-    @prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+    PREFIX :      <http://example/>
+    PREFIX dc:    <http://purl.org/dc/elements/1.1/>
+    PREFIX foaf:  <http://xmlns.com/foaf/0.1/>
+    PREFIX rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
     
     :book   dc:author  ( :a :b ) .
     
@@ -183,10 +180,10 @@ to use the short label form.
 
 Example:
 
-    @prefix :  <http://example/> .
-    @prefix dc:  <http://purl.org/dc/elements/1.1/> .
-    @prefix foaf:  <http://xmlns.com/foaf/0.1/> .
-    @prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+    PREFIX dc:  <http://purl.org/dc/elements/1.1/>
+    PREFIX :  <http://example/>
+    PREFIX foaf:  <http://xmlns.com/foaf/0.1/>
+    PREFIX rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
     
     :book   dc:author  _:b0 .
     
@@ -225,10 +222,10 @@ Example:
 The FLAT writers abbreviates IRIs, literals and blank node labels
 but always writes one complete triple on one line (no use of `;`).
 
-    @prefix :  <http://example/> .
-    @prefix dc:  <http://purl.org/dc/elements/1.1/> .
-    @prefix foaf:  <http://xmlns.com/foaf/0.1/> .
-    @prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+    PREFIX :  <http://example/>
+    PREFIX dc:  <http://purl.org/dc/elements/1.1/>
+    PREFIX foaf:  <http://xmlns.com/foaf/0.1/>
+    PREFIX rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
     _:b0 foaf:name "Bob" .
     :book dc:author _:b1 .
     _:b2 rdf:rest rdf:nil .
@@ -263,8 +260,8 @@ otherwise noted, the setting applies to both Turtle and TriG.
 | Directive Style | Effect |
 |------------------|-------|
 | "sparql", "rdf11"    | Use `PREFIX` and `BASE` in output.   |
-| "at", "n3"           | Use `@prefix` and `@base` in output. |
-| unset                | Use `@prefix` and `@base` in output. |
+| "at", "rdf10         | Use `@prefix` and `@base` in output. |
+| unset                | Use `PREFIX` and `BASE` in output.   |
 
 <p>&nbsp;</b>
 
@@ -272,7 +269,7 @@ otherwise noted, the setting applies to both Turtle and TriG.
 
 ##### _Setting directive style_
 ```
-    riot --set ttl:directiveStyle=sparql --pretty Turtle file1.rdf file2.nt ...
+    riot --set ttl:directiveStyle=rdf11 --pretty Turtle file1.rdf file2.nt ...
 ```
 and in code:
 ```
@@ -288,7 +285,7 @@ and in code:
 ```
 and in code:
 ```
-RDFWriter.source(model)
+  RDFWriter.source(model)
      .format(RDFFormat.TURTLE_LONG)
      .output(System.out);
 ```
@@ -438,6 +435,8 @@ while the jena writer name defaults to a streaming plain output.
 | RDFXML    | RDFXML_PRETTY, RDF_XML_ABBREV | "RDF/XML-ABBREV" |
 | RDFXML_PLAIN |                            | "RDF/XML"        |
 
+More details [RDF/XML Output](rdfxml-io.html#rdfxml-output).
+
 ## Examples {#examples}
 
 Example code may be found in [jena-examples:arq/examples](https://github.com/apache/jena/tree/main/jena-examples/src/main/java/arq/examples/riot/).
@@ -446,27 +445,27 @@ Example code may be found in [jena-examples:arq/examples](https://github.com/apa
 
 The follow ways are different ways to write a model in Turtle:
 
-        Model model =  ... ;
+      Model model =  ... ;
 
-        // Write a model in Turtle syntax, default style (pretty printed)
-        RDFDataMgr.write(System.out, model, Lang.TURTLE) ;
+      // Write a model in Turtle syntax, default style (pretty printed)
+      RDFDataMgr.write(System.out, model, Lang.TURTLE) ;
         
-        // Write Turtle to the blocks variant
-        RDFDataMgr.write(System.out, model, RDFFormat.TURTLE_BLOCKS) ;
+      // Write Turtle to the blocks variant
+      RDFDataMgr.write(System.out, model, RDFFormat.TURTLE_BLOCKS) ;
         
-        // Write as Turtle via model.write
-        model.write(System.out, "TTL") ;
+      // Write as Turtle via model.write
+      model.write(System.out, "TTL") ;
 
 ### Ways to write a dataset
 
 The preferred style is to use `RDFDataMgr`:
 
-    Dataset ds = .... ;
-    // Write as TriG
-    RDFDataMgr.write(System.out, ds, Lang.TRIG) ;
+      Dataset ds = .... ;
+      // Write as TriG
+      RDFDataMgr.write(System.out, ds, Lang.TRIG) ;
 
-    // Write as N-Quads
-    RDFDataMgr.write(System.out, dataset, Lang.NQUADS) ;
+      // Write as N-Quads
+      RDFDataMgr.write(System.out, dataset, Lang.NQUADS) ;
 
 Additionally, a single model can be written in a dataset format - it becomes
 the default graph of the dataset.
@@ -476,10 +475,10 @@ the default graph of the dataset.
 
 might give:
 
-    @prefix :      <http://example/> .
-    @prefix dc:    <http://purl.org/dc/elements/1.1/> .
-    @prefix foaf:  <http://xmlns.com/foaf/0.1/> .
-    @prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+    PREFIX :      <http://example/>
+    PREFIX dc:    <http://purl.org/dc/elements/1.1/>
+    PREFIX foaf:  <http://xmlns.com/foaf/0.1/>
+    PREFIX rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 
     {
         :book   dc:author  ( :a :b ) .

--- a/source/documentation/io/rdfxml-input.md
+++ b/source/documentation/io/rdfxml-input.md
@@ -1,14 +1,56 @@
 ---
-title: Jena RDF/XML Input How-To
+title: Jena RDF/XML Input How-To (ARP)
 ---
 
-_Legacy Documentation : may not be up-to-date_
+___Legacy Documentation : not up-to-date___
 
-Original [RDF/XML HowTo](rdfxml_howto.html).
+___The original ARP parser will be removed from Jena.___
+
+The current RDF/XML parser is RRX.
 
 ---
 
-This is a guide to the RDF/XML legacy input subsystem of Jena, ARP.
+This is a guide to the RDF/XML legacy ARP input subsystem of Jena.
+
+
+The ARP RDF/XML parser is designed for use with RIOT and to have the same handling
+of errors, IRI resolution, and treatment of base IRIs as other RIOT readers.
+
+The ARP0 parser is the original standalone parser.
+
+## RDF/XML Input
+
+The usual way to access the RDF/XML parser is via `RDFDataMgr` or `RDFParser`.
+
+    Model model = RDFDataMgr.loadModel("data.arp");
+
+or
+
+    Model model = RDFParser.source("data.arp").toModel();
+
+Note the file extension is _arp_.
+
+### Legacy ARP RDF/XML parser
+
+#### RIOT integrated ARP parser
+
+To access the parse from Java code use constants `RRX.RDFXML_ARP1`.
+
+The syntax name is `arp` or `arp1`.
+
+The file extension is _arp_ or `arp1`.
+
+#### Original ARP0 parser
+
+To access the parse from Java code use constants `RRX.RDFXML_ARP0`.
+
+The syntax name is `arp0`.
+
+The file extension is _arp0_.
+
+Details of the original Jena RDF/XML parser, [ARP](arp/arp.html).
+
+---
 
 ## Advanced RDF/XML Input
 
@@ -139,7 +181,3 @@ The global default IRI engine can be set with:
     ARPOptions.setIRIFactoryGlobal(IRIFactory.iriImplementation()) ;
 
 or other IRI rule engine from `IRIFactory`.
-
-## Further details
-
-[Details of ARP, the Jena RDF/XML parser](arp/arp.html)

--- a/source/documentation/io/rdfxml-io.md
+++ b/source/documentation/io/rdfxml-io.md
@@ -2,41 +2,17 @@
 title: Jena RDF XML
 ---
 
-This is a guide to the RDF/XML I/O subsystem of Jena.
-
-The RDF/XML parser is designed for use with RIOT and to have the same handling
-of errors, IRI resolution, and treatment of base IRIs as other RIOT readers.
-
+- [RDF/XML Input](#rdfxml-input)
+- [RDF/XML Output](#rdfxml-output)
 
 ## RDF/XML Input
 
-The usual way to access the RDF/XML parser is via `RDFDataMgr` or `RDFParser`.
+The RIOT RDF/XML parser is called RRX.
 
-    Model model = RDFDataMgr.loadModel("data.rdf");
 
-or
+The ARP RDF/XML parser is stil available but wil be rmoved from Apache Jena.
 
-    Model model = RDFParser.source("data.rdf").toModel();
-
-The original "ARP" parser is still available bu tmaybe pahsed out.  To access
-the legacy parser, use the context symbol `RIOT.symRDFXML0` to `true` or
-`"true".
-
-    Model model = RDFParser.source(""data.rdf")
-                           .set(RIOT.symRDFXML0, true)
-                           .parse(dest);
-
-This applies to the command line:
-
-    riot --set rdfxml:rdfxml0=true data.rdf
-
-This can be set globally in the JVM:
-
-    RIOT.getContext().set(RIOT.symRDFXML0, "true");
-
-Details of [legacy RDF/XML input](rdfxml-input.html).
-
-Details of the original Jena RDF/XML parser, [ARP](arp/arp.html).
+- Legacy ARP [RDF/XML input](rdfxml-input.html)
 
 ## RDF/XML Output
 
@@ -67,5 +43,4 @@ or
 
     RDFWriter.source(model).format(RDFFormat.RDFXML_PLAIN).output(System.out);
 
-
-Details of [legacy RDF/XML output](rdfxml-output.html).
+- [RDF/XML advanced output](rdfxml-output.html)

--- a/source/documentation/io/rdfxml-output.md
+++ b/source/documentation/io/rdfxml-output.md
@@ -2,19 +2,13 @@
 title: Jena RDF/XML Output How-To
 ---
 
-_Legacy Documentation : may not be up-to-date_
-
-Original [RDF/XML HowTo](rdfxml_howto.html).
-
----
-
 ## Advanced RDF/XML Output
 
 Two forms for output are provided: pretty printed RDF/XML ("RDF/XML-ABBREV") or plain RDF/XML
 
 While some of the code is shared, these
 two writers are really very different, resulting in different but
-equivalent output. "RDF/XML-ABBREV" is slower, but should produce
+equivalent RDF output. "RDF/XML-ABBREV" is slower, but should produce
 more readable XML.
 
 ### Properties to Control RDF/XML Output

--- a/source/documentation/io/rdfxml_howto.md
+++ b/source/documentation/io/rdfxml_howto.md
@@ -4,6 +4,8 @@ title: Jena RDF/XML How-To
 
 _Legacy Documentation : may not be up-to-date_
 
+* The original ARQ parser will be removed from Jena. *
+
 ---
 
 This is a guide to the RDF/XML I/O subsystem of Jena, ARP.

--- a/source/documentation/javadoc.md
+++ b/source/documentation/javadoc.md
@@ -2,13 +2,13 @@
 title: Jena JavaDoc
 ---
 
-- [Jena Core JavaDoc](javadoc/jena/index.html)
-- [ARQ JavaDoc (SPARQL)](javadoc/arq/index.html)
-- [TDB JavaDoc](javadoc/tdb2/index.html)
-- [RDF Connection](javadoc/rdfconnection/index.html)
+- [Jena Core](javadoc/jena/index.html)
 - Fuseki JavaDoc
   - [Fuseki2 Webapp](javadoc/fuseki2/index.html)
   - [Fuseki2 Main](javadoc/fuseki2-main/index.html)
+- [ARQ(SPARQL)](javadoc/arq/index.html)
+- [RDF Connection](javadoc/rdfconnection/index.html)
+- [TDB](javadoc/tdb2/index.html)
 - [Text search](javadoc/text/index.html)
 - [SHACL](javadoc/shacl/index.html)
 - [ShEx](javadoc/shex/index.html)

--- a/source/documentation/notes/sse.md
+++ b/source/documentation/notes/sse.md
@@ -295,21 +295,6 @@ There is a default prefix mapping with a few common prefixes: `rdf`,
 `rdfs`, `owl`, `xsd` and `fn` (the XPath/XQuery functions and operators
 namespace).
 
-## Mapping to RDF
-
-The syntax of SSE is very close to Turtle lists because the syntax for
-IRIs and literals are the same.: to produce Turtle (outline):
-
-1.  Replace symbols by IRIs: prepend a common URI and %-encode any
-    characters necessary.
-2.  Replace variables by IRIs: prepend a common URI.
-3.  Move prefixes to be `@prefix` directives.
-4.  Put a dot at the end of the file.
-
-The result is an RDF model using only the properties `rdf:first` and
-`rdf:rest` so it records the data structure, but not what the data
-structure represents.
-
 ## SSE Files
 
 The file extension is `.sse` and all files are UTF-8.

--- a/source/documentation/notes/stream-manager.md
+++ b/source/documentation/notes/stream-manager.md
@@ -35,7 +35,7 @@ Location mapping files are RDF - they may be written in RDF/XML, Turtle
 (file suffix `.ttl`) or N-Triples (file suffix `.nt`). The default
 is RDF/XML unless one of these suffices is found.
 
-    @prefix lm: <http://jena.hpl.hp.com/2004/08/location-mapping#> .
+    PREFIX lm: <http://jena.hpl.hp.com/2004/08/location-mapping#>
 
     [] lm:mapping
        [ lm:name "file:foo.ttl" ;     lm:altName "file:etc/foo.ttl" ] ,

--- a/source/documentation/permissions/assembler.md
+++ b/source/documentation/permissions/assembler.md
@@ -11,7 +11,7 @@ The secured assembler provides XXXXXXXXXXXx properties for the assembler files.
 
 Assuming we define:
 
-     @prefix sec:    <http://apache.org/jena/permissions/Assembler#> .
+     PREFIX sec:    <http://apache.org/jena/permissions/Assembler#>
 
 Then the following resources are defined:
 

--- a/source/documentation/permissions/example.md
+++ b/source/documentation/permissions/example.md
@@ -10,8 +10,6 @@ To do this you will need a Fuseki installation, the Permissions Packages and a S
 
 ## Set up
 
-This example uses Fuseki 2.3.0 or higher, Permissions 3.1.0 or higher and Apache Commons Collections v4.
-
 Fuseki can be downloaded from:
 <https://repository.apache.org/content/repositories/releases/org/apache/jena/apache-jena-fuseki/>
 
@@ -74,13 +72,13 @@ graph.
 
 Define all the prefixes.
 
-    @prefix fuseki:  <http://jena.apache.org/fuseki#> .
-    @prefix tdb:     <http://jena.hpl.hp.com/2008/tdb#> .
-    @prefix rdf:     <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
-    @prefix rdfs:    <http://www.w3.org/2000/01/rdf-schema#> .
-    @prefix ja:      <http://jena.hpl.hp.com/2005/11/Assembler#> .
-    @prefix perm:    <http://apache.org/jena/permissions/Assembler#> .
-    @prefix my:     <http://example.org/#> .
+    PREFIX fuseki:  <http://jena.apache.org/fuseki#>
+    PREFIX tdb:     <http://jena.hpl.hp.com/2008/tdb#>
+    PREFIX rdf:     <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+    PREFIX rdfs:    <http://www.w3.org/2000/01/rdf-schema#>
+    PREFIX ja:      <http://jena.hpl.hp.com/2005/11/Assembler#>
+    PREFIX perm:    <http://apache.org/jena/permissions/Assembler#>
+    PREFIX my:      <http://example.org/#>
 
 
 Load the SecuredAssembler class from the permissions library and define the perm:Model as a subclass of ja:NamedModel.

--- a/source/documentation/query/text-query.md
+++ b/source/documentation/query/text-query.md
@@ -719,13 +719,13 @@ The following is an example of an assembler file defining a TDB dataset with a L
     # See https://jena.apache.org/documentation/fuseki2/fuseki-layout.html for the destination of this file.
     #########################################################################
     
-    @prefix :        <http://localhost/jena_example/#> .
-    @prefix rdf:     <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
-    @prefix rdfs:    <http://www.w3.org/2000/01/rdf-schema#> .
-    @prefix tdb:     <http://jena.hpl.hp.com/2008/tdb#> .
-    @prefix text:    <http://jena.apache.org/text#> .
-    @prefix skos:    <http://www.w3.org/2004/02/skos/core#>
-    @prefix fuseki:  <http://jena.apache.org/fuseki#> .
+    PREFIX :        <http://localhost/jena_example/#>
+    PREFIX rdf:     <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+    PREFIX rdfs:    <http://www.w3.org/2000/01/rdf-schema#>
+    PREFIX tdb:     <http://jena.hpl.hp.com/2008/tdb#>
+    PREFIX text:    <http://jena.apache.org/text#>
+    PREFIX skos:    <http://www.w3.org/2004/02/skos/core#>
+    PREFIX fuseki:  <http://jena.apache.org/fuseki#>
 
     [] rdf:type fuseki:Server ;
        fuseki:services (

--- a/source/documentation/rdf/__index.md
+++ b/source/documentation/rdf/__index.md
@@ -160,12 +160,12 @@ where `acme-product` is defined to be `http://acme.example/schema/products#`. Th
 for example, in Turtle:
 
 ```turtle
-@prefix acme-product: <http://acme.example/schema/products#>.
+PREFIX acme-product: <http://acme.example/schema/products#>
 
 acme-product:widget acme-product:price "44.99"^^xsd:decimal.
 ```
 
-The datatype `xsd:decimal` is another example of an abbreviated URI. Note that no `@prefix` rules
+The datatype `xsd:decimal` is another example of an abbreviated URI. Note that no `PREFIX` rules
 are defined by RDF or Turtle: authors of RDF content should ensure that all prefixes used in curies
 are defined before use.
 

--- a/source/documentation/rdf/datasets.md
+++ b/source/documentation/rdf/datasets.md
@@ -57,8 +57,8 @@ with data read from URLs (files or from any other URL).
 
 The examples use the following prefixes:
 
-    @prefix ja:     <http://jena.hpl.hp.com/2005/11/Assembler#> .
-    @prefix rdf:    <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+    PREFIX ja:     <http://jena.hpl.hp.com/2005/11/Assembler#>
+    PREFIX rdf:    <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 
 To create an empty in-memory dataset, all that is required is the line:
 

--- a/source/download/__index.md
+++ b/source/download/__index.md
@@ -19,7 +19,7 @@ Source release: this forms the official release of Apache Jena. All binaries art
 
 | Apache Jena Release | SHA512 | Signature |
 | ------------ | :----: | :-------: |
-|<a href="[preferred]jena/source/jena-5.0.0-rc1-source-release.zip">jena-5.0.0-rc1-source-release.zip</a> | [SHA512](https://downloads.apache.org/jena/source/jena-5.0.0-rc1-source-release.zip.sha512) | [PGP](https://downloads.apache.org/jena/source/jena-5.0.0-rc1-source-release.zip.asc) |
+|<a href="[preferred]jena/source/jena-5.0.0-source-release.zip">jena-5.0.0-source-release.zip</a> | [SHA512](https://downloads.apache.org/jena/source/jena-5.0.0-source-release.zip.sha512) | [PGP](https://downloads.apache.org/jena/source/jena-5.0.0-source-release.zip.asc) |
 
 ### Apache Jena Binary Distributions
 
@@ -27,28 +27,34 @@ The binary distribution of the Fuseki server:
 
 | Apache Jena Fuseki  | SHA512 | Signature |
 | ------------ | :----: | :-------: |
-| <a href="[preferred]jena/binaries/apache-jena-fuseki-5.0.0-rc1.tar.gz">apache-jena-fuseki-5.0.0-rc1.tar.gz</a> | [SHA512](https://downloads.apache.org/jena/binaries/apache-jena-fuseki-5.0.0-rc1.tar.gz.sha512) | [PGP](https://downloads.apache.org/jena/binaries/apache-jena-fuseki-5.0.0-rc1.tar.gz.asc) |
-| <a href="[preferred]jena/binaries/apache-jena-fuseki-5.0.0-rc1.zip">apache-jena-fuseki-5.0.0-rc1.zip</a> | [SHA512](https://downloads.apache.org/jena/binaries/apache-jena-fuseki-5.0.0-rc1.zip.sha512) | [PGP](https://downloads.apache.org/jena/binaries/apache-jena-fuseki-5.0.0-rc1.zip.asc) |
+| <a href="[preferred]jena/binaries/apache-jena-fuseki-5.0.0.tar.gz">apache-jena-fuseki-5.0.0.tar.gz</a> | [SHA512](https://downloads.apache.org/jena/binaries/apache-jena-fuseki-5.0.0.tar.gz.sha512) | [PGP](https://downloads.apache.org/jena/binaries/apache-jena-fuseki-5.0.0.tar.gz.asc) |
+| <a href="[preferred]jena/binaries/apache-jena-fuseki-5.0.0.zip">apache-jena-fuseki-5.0.0.zip</a> | [SHA512](https://downloads.apache.org/jena/binaries/apache-jena-fuseki-5.0.0.zip.sha512) | [PGP](https://downloads.apache.org/jena/binaries/apache-jena-fuseki-5.0.0.zip.asc) |
 
 <p>&nbsp;</p>
 The binary distribution of libraries contains the APIs, SPARQL engine, the TDB native RDF database and a variety of command line scripts and tools for working with these systems.
 
 | Apache Jena Commands | SHA512 | Signature |
 | ------------ | :----: | :-------: |
-|<a href="[preferred]jena/binaries/apache-jena-5.0.0-rc1.tar.gz">apache-jena-5.0.0-rc1.tar.gz</a> | [SHA512](https://downloads.apache.org/jena/binaries/apache-jena-5.0.0-rc1.tar.gz.sha512) | [PGP](https://downloads.apache.org/jena/binaries/apache-jena-5.0.0-rc1.tar.gz.asc) |
-| <a href="[preferred]jena/binaries/apache-jena-5.0.0-rc1.zip">apache-jena-5.0.0-rc1.zip</a> | [SHA512](https://downloads.apache.org/jena/binaries/apache-jena-5.0.0-rc1.zip.sha512) | [PGP](https://downloads.apache.org/jena/binaries/apache-jena-5.0.0-rc1.zip.asc)
+|<a href="[preferred]jena/binaries/apache-jena-5.0.0.tar.gz">apache-jena-5.0.0.tar.gz</a> | [SHA512](https://downloads.apache.org/jena/binaries/apache-jena-5.0.0.tar.gz.sha512) | [PGP](https://downloads.apache.org/jena/binaries/apache-jena-5.0.0.tar.gz.asc) |
+| <a href="[preferred]jena/binaries/apache-jena-5.0.0.zip">apache-jena-5.0.0.zip</a> | [SHA512](https://downloads.apache.org/jena/binaries/apache-jena-5.0.0.zip.sha512) | [PGP](https://downloads.apache.org/jena/binaries/apache-jena-5.0.0.zip.asc)
 
 <p>&nbsp;</p>
 The binary distribution of Fuseki as a WAR file:
 
 | Apache Jena Fuseki  | SHA512 | Signature |
 | ------------ | :----: | :-------: |
-| <a href="[preferred]jena/binaries/jena-fuseki-war-5.0.0-rc1.war">jena-fuseki-war-5.0.0-rc1.war</a> | [SHA512](https://downloads.apache.org/jena/binaries/jena-fuseki-war-5.0.0-rc1.war.sha512) | [PGP](https://downloads.apache.org/jena/binaries/jena-fuseki-war-5.0.0-rc1.war.asc)
+| <a href="[preferred]jena/binaries/jena-fuseki-war-5.0.0.war">jena-fuseki-war-5.0.0.war</a> | [SHA512](https://downloads.apache.org/jena/binaries/jena-fuseki-war-5.0.0.war.sha512) | [PGP](https://downloads.apache.org/jena/binaries/jena-fuseki-war-5.0.0.war.asc)
 |
 
 This can be run in any servlet application container supporting Jakarta Servlet 6.0
-(part of Jakarta EE version 9), such as  [Apache Tomcat](https://tomcat.apache.org/index.html) 10.1.x.
+(part of Jakarta EE version 9), such as [Apache Tomcat](https://tomcat.apache.org/index.html)
+10.x or later.
 The server must be running running on the required version of Java.
+
+### Apache Jena Download area
+
+The source release and also the binaries are available from the
+[Apache Jena Download area](https://downloads.apache.org/jena/).
 
 ### Individual Modules
 


### PR DESCRIPTION
- Tidy javadoc.md list 
- Release updates: downloads
- Default RDF/XML parser is now RRX; ARP will be removed
- Default Turtle uses PREFIX (RDF 1.1 style); `@prefix` available but not the default
