### PR TITLE
Escape pipe character in regex; it is not a column delimiter

### DIFF
--- a/source/documentation/query/library-function.md
+++ b/source/documentation/query/library-function.md
@@ -70,8 +70,8 @@ for compatibility.
 Function name | Description | Alternative
 ------------- | ----------- | -----------
 `afn:bnode(?x)`  | Return the blank node label if ?x is a blank node. | `STR(?x)`
-`afn:localname(?x)` | The local name of ?x | `REPLACE(STR(?x), "^(.*)(/|#)([^#/]*)$", "$3")`
-`afn:namespace(?x)` | The namespace of ?x  | `REPLACE(STR(?x), "^(.*)(/|#)([^#/]*)$", "$1")`
+`afn:localname(?x)` | The local name of ?x | `REPLACE(STR(?x), "^(.*)(/\|#)([^#/]*)$", "$3")`
+`afn:namespace(?x)` | The namespace of ?x  | `REPLACE(STR(?x), "^(.*)(/\|#)([^#/]*)$", "$1")`
 
 The prefix and local name of a IRI is based on splitting the IRI, not on any prefixes in the query or dataset.
 


### PR DESCRIPTION
The pipe character in the regular expression was being interpreted by GitHub Markdown as a table column delimiter.