### PR TITLE
Fix two typos: update -> upload

### DIFF
--- a/source/documentation/fuseki2/fuseki-configuration.md
+++ b/source/documentation/fuseki2/fuseki-configuration.md
@@ -108,8 +108,8 @@ The base name is `/ds`.
 
         fuseki:endpoint [ 
              # HTML file upload service
-            fuseki:operation fuseki:update ; 
-            fuseki:name "update" 
+            fuseki:operation fuseki:upload ; 
+            fuseki:name "upload" 
         ] ;
 
         fuseki:endpoint [ 


### PR DESCRIPTION
This PR fix two typos in an example: `fuseki:update` is for  SPARQL 1.1 Update; `fuseki:upload` is for HTML form file upload, see https://jena.apache.org/documentation/fuseki2/fuseki-config-endpoint.html#operations