### PR TITLE
Fix prefixes in Fuseki config examples

### DIFF
--- a/source/documentation/fuseki2/fuseki-configuration.md
+++ b/source/documentation/fuseki2/fuseki-configuration.md
@@ -56,8 +56,8 @@ Some useful prefix declarations:
     PREFIX fuseki:  <http://jena.apache.org/fuseki#>
     PREFIX rdf:     <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
     PREFIX rdfs:    <http://www.w3.org/2000/01/rdf-schema#>
-    PREFIX tdb1:    <http://jena.hpl.hp.com/2008/tdb#>
     PREFIX tdb2:    <http://jena.apache.org/2016/tdb#>
+    PREFIX tdb1:    <http://jena.hpl.hp.com/2008/tdb#>
     PREFIX ja:      <http://jena.hpl.hp.com/2005/11/Assembler#>
     PREFIX :        <#>
 
@@ -199,34 +199,30 @@ by searching the configuration file for the type `fuseki:Service`.
 
 An in-memory dataset, with data in the default graph taken from a local file.
 
-    <#books>    rdf:type ja:RDFDataset ;
-        rdfs:label "Books" ;
-        ja:defaultGraph
-          [ rdfs:label "books.ttl" ;
-            a ja:MemoryModel ;
-            ja:content [ja:externalContent <file:Data/books.ttl> ] ;
-          ] ;
+    <#dataset> rdf:type ja:MemoryDataset ;
+        ## Optional: load with data on start-up
+        ## ja:data <file:Data/books.ttl> 
         .
-
-### TDB
-
-    <#dataset> rdf:type      tdb:DatasetTDB ;
-        tdb:location "DB" ;
-        # Query timeout on this dataset (1s, 1000 milliseconds)
-        ja:context [ ja:cxtName "arq:queryTimeout" ;  ja:cxtValue "1000" ] ;
-        # Make the default graph be the union of all named graphs.
-        ## tdb:unionDefaultGraph true ;
-         .
 
 ### TDB2
 
-    <#dataset> rdf:type      tdb:DatasetTDB2 ;
-        tdb:location "DB2" ;
+    <#dataset> rdf:type      tdb2:DatasetTDB2 ;
+        tdb2:location "DB2" ;
         # Query timeout on this dataset (1s, 1000 milliseconds)
         ja:context [ ja:cxtName "arq:queryTimeout" ;  ja:cxtValue "1000" ] ;
         # Make the default graph be the union of all named graphs.
-        ## tdb:unionDefaultGraph true ;
-         .
+        ## tdb2:unionDefaultGraph true ;
+        .
+
+### TDB1
+
+    <#dataset> rdf:type      tdb1:DatasetTDB ;
+        tdb1:location "DB" ;
+        # Query timeout on this dataset (1s, 1000 milliseconds)
+        ja:context [ ja:cxtName "arq:queryTimeout" ;  ja:cxtValue "1000" ] ;
+        # Make the default graph be the union of all named graphs.
+        ## tdb1:unionDefaultGraph true ;
+        .
 
 ### Inference
 
@@ -242,7 +238,8 @@ You have to build up layers of dataset, inference model, and graph.
          ja:reasoner [ ja:reasonerURL <http://example/someReasonerURLHere> ];
          ja:baseModel <#baseModel>;
          .
-    <#baseModel> rdf:type tdb:GraphTDB2;  # for example.
+
+    <#baseModel> rdf:type tdb2:GraphTDB2;  # for example.
          tdb2:location "/some/path/to/store/data/to";
          # etc
          .


### PR DESCRIPTION
The changes suggested in #201.

* Use tdb1: and tdb2:
* Put TDB2 section first
* Fix the in-memory example

See also some sorting out java naming and adding "*TDB2" constant alternative names.
https://github.com/apache/jena/issues/2841

This aligns TDB1 and TDB2.
