### PR TITLE
Revise Fuseki for 'Server' and 'Plain'

### DIFF
--- a/source/documentation/fuseki2/__index.md
+++ b/source/documentation/fuseki2/__index.md
@@ -6,36 +6,30 @@ aliases:
     - /documentation/serving_data/index.html
 ---
 
-Apache Jena Fuseki is a SPARQL server.  It can run as an operating system
-service, as a Java web application (WAR file), and as a standalone server.
-
-Fuseki comes in two forms, a single system "webapp", combined with a UI
-for admin and query, and as "main", a server suitable to run as part of a larger
-deployment, including [with Docker](fuseki-main.html#docker) or running embedded.
-Both forms use the same core protocol engine and [same configuration file
-format](fuseki-configuration.html).
+Apache Jena Fuseki is a SPARQL server.  It can run as a standalone server, or embedded in an
+application.
 
 Fuseki provides the
 SPARQL 1.1 [protocols for query and update](http://www.w3.org/TR/sparql11-protocol/)
 as well as the
 [SPARQL Graph Store protocol](http://www.w3.org/TR/sparql11-http-rdf-update/).
 
-Fuseki is tightly integrated with [TDB](../tdb/index.html) to provide a robust,
-transactional persistent storage layer, and incorporates
+Fuseki is integrated with [TDB](../tdb/index.html) to provide a robust,
+transactional, persistent storage layer. Fuseki also incorporates
 [Jena text query](../query/text-query.html).
 
 ## Contents
 
-- [Download with UI](#download-fuseki-with-ui)
-- [Getting Started](#getting-started-with-fuseki)
-- [Running Fuseki with UI](fuseki-webapp.html)
-    - [As a standalone server with UI](fuseki-webapp.html#fuseki-standalone-server)
-    - [As a service](fuseki-webapp.html#fuseki-service)
-    - [As a web application](fuseki-webapp.html#fuseki-web-application)
+- [Download](#download-fuseki)
+- [Getting Started](fuseki-quick-start.html)
+- [Running Fuseki Server](fuseki-server.html)
+    - [As a standalone server](fuseki-server.html#fuseki-standalone-server)
+    - [As a service](fuseki-server.html#fuseki-service)
+    - [As a web application](fuseki-server.html#fuseki-web-application)
     - [Security](fuseki-security.html) with [Apache Shiro](https://shiro.apache.org/)
-- [Running Fuseki Server](fuseki-main.html)
-    - [Setup](fuseki-main.html#setup)
-    - [As a Docker container](fuseki-main#fuseki-docker)
+- [Running Fuseki Plain](fuseki-plain.html)
+    - [Setup](fuseki-plain.html#setup)
+    - [As a Docker container](fuseki-plain#fuseki-docker)
     - [As an embedded SPARQL server](fuseki-embedded.html)
     - [Security and data access control](fuseki-data-access-control.html)
     - [Logging](fuseki-logging.html)
@@ -44,7 +38,6 @@ transactional persistent storage layer, and incorporates
 - [How to Contribute](#how-to-contribute)
 - Client access
     - [Use from Java](../rdfconnection)
-    - [SPARQL Over HTTP](soh.html) - scripts to help with data management.
 - Extending Fuseki with [Fuseki Modules](fuseki-modules.html)
 - [Links to Standards](rdf-sparql-standards.html)
 
@@ -52,32 +45,36 @@ The Jena users mailing is the place to get help with Fuseki.
 
 [Email support lists](/help_and_support/#email-support-lists)
 
-## Download Fuseki with UI
+## Download Fuseki
 
-Releases of Apache Jena Fuseki can be downloaded from one of the mirror sites:
+Releases of Apache Jena Fuseki can be downloaded from:
 
 [Jena Downloads](/download)
-
-and previous releases are available from [the archive](https://archive.apache.org/dist/jena/).
-We strongly recommend that users use the latest official Apache releases of Jena Fuseki in
-preference to any older versions.
 
 **Fuseki download files**
 
 | Filename | Description |
 |---------|-------------|
-|`apache-jena-fuseki-*VER*.zip` | Fuseki with UI download |
-|[`jena-fuseki-server`](https://repo1.maven.org/maven2/org/apache/jena/jena-fuseki-server) | The Fuseki Main packaging |
+|`apache-jena-fuseki-*VER*.zip` | The Fuseki server and UI |
 
-`apache-jena-fuseki-*VER*.zip` contains both a war file and an executable jar.
-
-Fuskei Main is also available as a Maven artifact:
+The Fuseki engine is also available as a Maven artifact:
 
     <dependency>
        <groupId>org.apache.jena</groupId>
        <artifactId>jena-fuseki-main</artifactId>
        <version>X.Y.Z</version>
     </dependency>
+
+and the UI is available as:
+
+    <dependency>
+       <groupId>org.apache.jena</groupId>
+       <artifactId>jena-fuseki-ui</artifactId>
+       <version>X.Y.Z</version>
+    </dependency>
+
+
+A WAR file is also available from the Jena [download](/download) page.
 
 ### Previous releases
 
@@ -90,18 +87,10 @@ at [https://archive.apache.org/dist/jena](http://archive.apache.org/dist/jena/)
 
 ### Development Builds
 
-Regular development builds of all of Jena are available (these are not
-formal releases) from the
+Regular development builds of all of Jena are available 
+(these are not formal releases) from the
 [Apache snapshots maven repository](https://repository.apache.org/snapshots/org/apache/jena).
-This includes packaged builds of Fuseki.
-
-## Getting Started With Fuseki
-
-The [quick start](fuseki-quick-start.html) section serves as a basic
-guide to getting a Fuseki server running on your local machine.  
-
-See [all the ways to run Fuseki](fuseki-webapp.html) for complete coverage of all the
-deployment methods for Fuseki.
+This includes the packaged build of Fuseki.
 
 ## How to Contribute
 
@@ -127,16 +116,15 @@ The Fuseki code is under "jena-fuseki2/":
 
 | Code | Purpose |
 |---------------|--|
-| jena-fuseki-core | The Fuseki engine. All SPARQL operations.
-| <b>Fuseki/Main</b> | |
-| jena-fuseki-main   | Embedded server and command line 
-| jena-fuseki-server | Build the combined jar for Fusek/main server |
-| jena-fuseki-docker | Build a docker conntained based on Fusek/main |
-| <b>Webapp </b>     | |
-| jena-fuseki-webapp | Web application and command line startup |
-| jena-fuseki-fulljar | Build the combined jar for Fuseki/UI server |
-| jena-fuseki-war     | Build the war file for  Fusek/UI server |
-| apache-jena-fuseki  | The download for Fuskei |
+| jena-fuseki-main    | The Fuseki server |
+| jena-fuseki-core    | The Fuseki engine |
+| jena-fuseki-server  | Build the combined jar for Fuseki server |
+| jena-fuseki-access  | [Data access control](fuseki-data-access-control.html) |
+| apache-jena-fuseki  | The download for Fuseki |
 | <b>Other</b>        | |
-| jena-fuseki-access    | [Data access control](fuseki-data-access-control.html) |
+| jena-fuseki-docker  | Build a docker container for Fuseki |
 | jena-fuseki-geosparql | Integration for GeoSPARQL |
+| <b>Webapp</b>       | |
+| jena-fuseki-webapp  | Web application and command line startup |
+| jena-fuseki-fulljar | Build the combined jar for Fuseki/UI server |
+| jena-fuseki-war     | Build the war file for Fuseki/UI server |

--- a/source/documentation/fuseki2/fuseki-plain.md
+++ b/source/documentation/fuseki2/fuseki-plain.md
@@ -1,13 +1,14 @@
 ---
-title: "Fuseki : Main Server"
+title: "Fuseki : Plain Server"
 ---
 
-Fuseki main is a packaging of Fuseki as a triple store without a UI for administration.
+Fuseki Server can be run "plain" as a triple store without a UI.
+It can be run in the background by an application as an embedded server.  
+The entry point is `org.apache.jena.fuseki.main.cmds.FusekiMainCmd`.
 
-Fuseki can be run in the background by an application as an embedded server.  The
-application can safely work with the dataset directly from java while having Fuseki
-provide SPARQL access over HTTP.  An embedded server is useful for
-adding functionality around a triple store and also for development and testing.
+The application can safely work with the dataset directly from java while having Fuseki provide
+SPARQL access over HTTP.  An embedded server is useful for adding functionality around a triple
+store and also for development and testing.
 
 * [Running as a deployment or development server](#fuseki-server)
 * [Running from Docker](#fuseki-docker)
@@ -26,11 +27,10 @@ See also [Data Access Control for Fuseki](./fuseki-data-access-control.html).
 ## Running as a configured deployment or development server {#fuseki-server}
 
 The artifact `org.apache.jena:jena-fuseki-server` is a packaging of
-the "main" server that runs from the command line.  Unlike the UI 
-Fuseki server, it is only configured from the command line and has no
-persistent work area on-disk.
+the Fuseki server that runs from the command line.  Unlike the UI 
+Fuseki server, running this way has no persistent work area on-disk.
 
-    java -jar jena-fuseki-server-$VER.jar --help
+    java -cp jena-fuseki-server-$VER.jar org.apache.jena.fuseki.main.cmds.FusekiMainCmd --help
 
 The arguments are the same as the 
 [full UI server command line program](/documentation/fuseki2/fuseki-webapp.html#fuseki-standalone-server).

--- a/source/documentation/fuseki2/fuseki-quick-start.md
+++ b/source/documentation/fuseki2/fuseki-quick-start.md
@@ -4,27 +4,33 @@ title: Fuseki Quickstart
 
 This page describes how to achieve certain common tasks in the most direct way possible.
 
-## Running with Apache Tomcat and loading a file.
+## Running with Apache Jena Fuseki loading a file.
 
-1. Unpack the distribution.
-2. Copy the WAR file into the Apache tomcat webapp directory, under the name 'fuseki'
-3. If the user under which Apache tomcat is running does not have write access to `/etc`, then please make sure to set the environment variable FUSEKI_BASE, whereas the value should be a directory where the user running Apache tomcat is able to write to.
-4. In a browser, go to `[http://localhost:8080/fuseki/](http://localhost:8080/fuseki)` (details such as port number depend on the Tomcat setup).
+1. [Download](https://jena.apache.org/download/) the versioned distribution file 
+   `apache-jena-fuseki-VER.zip'
+2. Unpack the distribution. The directory will be `apache-jena-fuseki-VER/`
+3. Run the script `fuseki-server`, or `fuseki-server.bat`.
+4. In your browser, go to [http://localhost:3030/](http://localhost:3030/fuseki)
+  (details such as port number depend optional arguments on the start-up script).
 5. Click on "Add one", choose "in-memory", choose a name for the URL for the dataset.
 6. Go to "add data" and load the file (single graph).
+
+Try `fuseki-server --help` for command line options.
 
 ## Publish an RDF file as a SPARQL endpoint.
 
 1. Unpack the distribution.
-2. Run `fuseki-server --file FILE /name`
+2. Run <tt>fuseki-server --file <i>FILE</i> /<i>name</i></tt>
+
+The SPARQL endpoint will be <tt>http://localhost:3030/<i>name</i>/sparql</tt>
+and the SPARQL UI at <tt>http://localhost:3030/#/dataset/<i>name</i>/query</tt>.
 
 ## Explore a TDB database
 
 1. Unpack the distribution.
-2. Run `fuseki-server --loc=DATABASE /name`
-3. In a browser, go to `http://localhost:3030//query.html`
+2. Run <tt>fuseki-server --loc=<i>DATABASE</i> /<i>name</i></tt>
+3. In a browser, go to <tt>http://localhost:3030/#/dataset/<i>name</i>/query.html</tt>
 
-More details on running Fuseki can be found [nearby](fuseki-webapp.html),
-including running as an operating system service and in a web app or
-servlet container such as [Apache Tomcat](http://tomcat.apache.org/) or
-[Jetty](http://eclipse.org/jetty).
+More details on running Fuseki can be found on the [Fuseki Server](fuseki-server.html) page,
+including running as an operating system service or as a web app on a
+servlet container such as [Apache Tomcat](http://tomcat.apache.org/).

--- a/source/documentation/fuseki2/fuseki-server.md
+++ b/source/documentation/fuseki2/fuseki-server.md
@@ -1,15 +1,17 @@
 ---
-title: Running Fuseki with UI
+title: Running Fuseki
 ---
 
-Fuseki/UI can be run in a number of ways:
+Fuseki can be run as:
 
-* [As a standalone server](#fuseki-standalone-server)
-* [As a service](#fuseki-service) run by the operation system, for example, started when the machine boots
+* [As a standalone server with UI](#fuseki-standalone-server)
+* [As a service](#fuseki-service) run by the operation system, 
+   for example, started when the machine boots
+* Embbeded in an application, with or without a UI
 * [As a Web Application](#fuseki-web-application) inside a container such as Apache Tomcat or Jetty.
 
-Fuseki is also packaged as a plain server ["Fuseki Main"](fuseki-main.html)
-with no UI for use as a configurable SPARQL server, for [building as a Docker
+Fuseki is also packaged as a plain server ["Fuseki Plain"](fuseki-plain.html)
+with no UI for use as a configurable SPARQL server for [building as a Docker
 container](fuseki-docker.html), and as a deployment and development standalone
 server. It supports the arguments used by the standalone server. 
 
@@ -22,7 +24,7 @@ how to provide datasets and configure services using the configuration file.
 
 This is running Fuseki from the command line.
 
-To publish at <tt>http://<i>host</i>:3030/NAME</i></tt>:
+To publish at `http://host:3030/NAME`:
 
 where `/NAME` is the dataset publishing name at this server in URI space.
 
@@ -48,6 +50,12 @@ where `MyData.ttl` can be any RDF format, both triples or quads.
 Administrative functions are only available from "localhost".
 
 See `fuseki-server --help` for details of more arguments.
+
+## Configuring logging
+
+Fuseki uses Apache Log4j2 for logging. This can be configured via 
+a `log4j2.properties` file. The `fuseki-server` script looks for
+such a file in the current direcory.
 
 ## Layout
 
@@ -96,8 +104,6 @@ local machine.
 When deploying as a web application a more fully featured Admin API is
 made available and described on the 
 [Fuseki Server Protocol (REST API)](fuseki-server-protocol.html) page.
-
-## Configuring logging
 
 When running from a WAR file in a webapp container such as Apache Tomcat, the
 logging configuration comes from the file `log4j2.properties` in the root of the


### PR DESCRIPTION
Basic update for the new (5.3.0) fuseki-server.jar and being about to run with UI and plain (no UI, no on disk area).
