### PR TITLE
[INFRA] Set up default rulesets for default and release branches

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -1,9 +1,9 @@
 ## Licensed under the terms of http://www.apache.org/licenses/LICENSE-2.0
 
 notifications:
-    commits:       commits@jena.apache.org
-    issues:        issues@jena.apache.org
-    pullrequests:  pr@jena.apache.org
+  commits: commits@jena.apache.org
+  issues: issues@jena.apache.org
+  pullrequests: pr@jena.apache.org
 
 github:
   description: "Website sources for the Apache Jena website"
@@ -13,8 +13,7 @@ github:
     - jena
     - hugo
     - website
-  protected_branches:
-    main
+  protected_branches: main
   features:
     issues: true
     discussions: false
@@ -22,3 +21,16 @@ github:
     squash: false
     rebase: true
     merge: false
+  rulesets:
+    - name: "Default Branch Protection"
+      type: branch
+      branches:
+        includes:
+          - "~DEFAULT_BRANCH"
+          - "release/*"
+          - "rel/*"
+        excludes: []
+      bypass_teams:
+        - root
+      restrict_deletion: true
+      restrict_force_push: true


### PR DESCRIPTION
This Pull Request enables the repository to conform with the "sane default security settings" of the Apache Software Foundation by configuring a default branch ruleset that protects the default branch and any release branches.

Note that `~DEFAULT_BRANCH` is a GitHub symbolic link to the current default branch (HEAD) of the repository and does not need changing.
If the managing project does not wish to set up these defaults, please close this Pull Request. Alternatively, the project may merge this Pull Request to apply the changes immediately.

If no action is taken, this Pull Request will be automatically merged by the Apache Infrastructure team on **2026-06-14** (30 days from now).

For any further information, please reach us on Slack or at: users@infra.apache.org
