### PR TITLE
Remove old protected_branches in favour of branch protection rules

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -13,7 +13,6 @@ github:
     - jena
     - hugo
     - website
-  protected_branches: main
   features:
     issues: true
     discussions: false


### PR DESCRIPTION
`.asf.yaml` processing is not liking the `protected_branches: main`. `protected_branches` values should be an object as it is on the code repo.

(https://github.com/apache/infrastructure-asfyaml/blob/main/README.md)

As this is now covered by the "Default Branch Protection" ruleset, we can remove that line.

There are also a bunch of changes showing on a Jenkins job but they look like bringing files up-to-date in the ASF gitbox (because of the syntax error on `protected_branches`?).

